### PR TITLE
Allow python_pip builder to install relative packages

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import logging
 from email.parser import FeedParser
+from os import chdir, getcwd, path
 
 
 from .compat import pip_import_string
@@ -328,9 +329,12 @@ class DependencyBuilder(object):
         # the dependency graph. Return the set of all package objects
         # which will serve as the master list of dependencies needed to deploy
         # successfully.
+        orig_cwd = getcwd()
+        chdir(path.dirname(requirements_filename))
         self._pip.download_all_dependencies(requirements_filename, directory)
         deps = {Package(directory, filename) for filename
                 in self._osutils.get_directory_contents(directory)}
+        chdir(orig_cwd)
         LOG.debug("Full dependency closure: %s", deps)
         return deps
 


### PR DESCRIPTION
Local requirements.txt references are relative to the process's cwd.
This changes the cwd during pip install, so `sam build` processes
relative to the location of requirements.txt, in the same way
`sam build --use-container` does.

Semantic differences between the purpose of requirements.txt and
setup.py:
* setup.py defines a project/libray and its specific dependancies;
supports additional project features: runtime version restriction,
extra_requires, entrypoints
* requirements.txt is a list of things to install, defining an
application's environment

This change provides support for installing packages using setup.py.
If your application is also a package, including "." in your
requirements.txt will defer dependancies resloution to your package's
setup.py.

This change also provides support for local sub-packages.  If your
application contains local sub-packages, listing them in the form of
"./<packagename>" in your requirements.txt will allow you to resolve
and install each package's dependancies.

Fixes #152

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
