### PR TITLE
Added maven dependency flag to include groupIds when copying dependen…

### DIFF
--- a/aws_lambda_builders/workflows/java_maven/maven.py
+++ b/aws_lambda_builders/workflows/java_maven/maven.py
@@ -34,7 +34,7 @@ class SubprocessMaven(object):
             raise MavenExecutionError(message=stdout.decode("utf8").strip())
 
     def copy_dependency(self, scratch_dir):
-        args = ["dependency:copy-dependencies", "-DincludeScope=compile"]
+        args = ["dependency:copy-dependencies", "-DincludeScope=compile", "-Dmdep.prependGroupId=true"]
         ret_code, stdout, _ = self._run(args, scratch_dir)
 
         if ret_code != 0:

--- a/tests/integration/workflows/java_maven/test_java_maven.py
+++ b/tests/integration/workflows/java_maven/test_java_maven.py
@@ -28,7 +28,7 @@ class TestJavaMaven(TestCase):
         expected_files = [
             p("aws", "lambdabuilders", "Main.class"),
             p("some_data.txt"),
-            p("lib", "annotations-2.1.0.jar"),
+            p("lib", "software.amazon.awssdk.annotations-2.1.0.jar"),
         ]
         self.assert_artifact_contains_files(expected_files)
         self.assert_artifact_not_contains_file(p("lib", "junit-4.12.jar"))

--- a/tests/unit/workflows/java_maven/test_maven.py
+++ b/tests/unit/workflows/java_maven/test_maven.py
@@ -61,7 +61,7 @@ class TestSubprocessMaven(TestCase):
         maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
         maven.copy_dependency(self.source_dir)
         self.os_utils.popen.assert_called_with(
-            [self.maven_path, "dependency:copy-dependencies", "-DincludeScope=compile"],
+            [self.maven_path, "dependency:copy-dependencies", "-DincludeScope=compile", "-Dmdep.prependGroupId=true"],
             cwd=self.source_dir,
             stderr=subprocess.PIPE,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
This pull-request fixes issue #194 by having maven dependency copy-dependencies to include the group id in the file name of all dependency jars


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
