### PR TITLE
Reduce generated binary size

### DIFF
--- a/aws_lambda_builders/workflows/go_modules/builder.py
+++ b/aws_lambda_builders/workflows/go_modules/builder.py
@@ -50,6 +50,9 @@ class GoModulesBuilder(object):
         if self.mode and self.mode.lower() == BuildMode.DEBUG:
             LOG.debug("Debug build requested: Setting configuration to Debug")
             cmd += ["-gcflags='all=-N -l'"]
+        else:
+            cmd += ["-ldflags='-s -w'"]
+            
         cmd += ["-o", output_path, source_dir_path]
 
         p = self.osutils.popen(cmd, cwd=source_dir_path, env=env, stdout=self.osutils.pipe, stderr=self.osutils.pipe)


### PR DESCRIPTION
Adding the `ldflags` `-s -w` will reduce the size of the generated binary.

-s  disable symbol table
-w  disable DWARF generation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
