### PR TITLE
chore: Remove python patch version in AppVeyor to be more robust

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,25 +12,25 @@ environment:
   matrix:
 
   - PYTHON: "C:\\Python27-x64"
-    PYTHON_VERSION: '2.7.18'
+    PYTHON_VERSION: '2.7'
     PYTHON_ARCH: '64'
     LINE_COVERAGE: '91'
     NEW_FLAKE8: 0
     JAVA_HOME: "C:\\Program Files\\Java\\jdk11"
   - PYTHON: "C:\\Python36-x64"
-    PYTHON_VERSION: '3.6.10'
+    PYTHON_VERSION: '3.6'
     PYTHON_ARCH: '64'
     LINE_COVERAGE: '91'
     NEW_FLAKE8: 0
     JAVA_HOME: "C:\\Program Files\\Java\\jdk11"
   - PYTHON: "C:\\Python37-x64"
-    PYTHON_VERSION: '3.7.7'
+    PYTHON_VERSION: '3.7'
     PYTHON_ARCH: '64'
     LINE_COVERAGE: '91'
     NEW_FLAKE8: 0
     JAVA_HOME: "C:\\Program Files\\Java\\jdk11"
   - PYTHON: "C:\\Python38-x64"
-    PYTHON_VERSION: '3.8.2'
+    PYTHON_VERSION: '3.8'
     PYTHON_ARCH: '64'
     LINE_COVERAGE: '72'
     NEW_FLAKE8: 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Refer to https://github.com/aws/aws-sam-cli/pull/2386:

When AppVeyor updates their python env, like from 3.7.7 to 3.7.9, 3.7.7 won't be available, and builds will fail due to the error:
```
/opt/appveyor/build-agent/bash-shell.sh: line 51: /home/appveyor/venv3.7.7/bin/activate: No such file or directory
```

According to AppVeyor doc, we don't have to specify patch version: https://www.appveyor.com/docs/linux-images-software/#python

<img width="750" alt="image" src="https://user-images.githubusercontent.com/3804518/99479104-6ec8d780-290a-11eb-8d29-a41063180925.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
