### PR TITLE
fix: run GlobalToolInstallAction in a lock block and only once

### DIFF
--- a/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
@@ -48,11 +48,13 @@ class GlobalToolInstallAction(BaseAction):
                 LOG.debug("Error installing probably due to already installed. Attempt to update to latest version.")
                 try:
                     self.subprocess_dotnet.run(
-                        ["tool", "update", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
+                        ["tool", "update", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
+                    )
                     GlobalToolInstallAction.__tools_installed = True
                 except DotnetCLIExecutionError as ex:
                     raise ActionFailedError(
-                        "Error configuring the Amazon.Lambda.Tools .NET Core Global Tool: " + str(ex))
+                        "Error configuring the Amazon.Lambda.Tools .NET Core Global Tool: " + str(ex)
+                    )
 
 
 class RunPackageAction(BaseAction):

--- a/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 
 class GlobalToolInstallAction(BaseAction):
     __lock = threading.Lock()
-    __tolls_installed = False
+    __tools_installed = False
 
     """
     A Lambda Builder Action which installs the Amazon.Lambda.Tools .NET Core Global Tool
@@ -36,22 +36,23 @@ class GlobalToolInstallAction(BaseAction):
             LOG.debug("Entered synchronized block for updating Amazon.Lambda.Tools")
 
             # check if Amazon.Lambda.Tools updated recently
-            if GlobalToolInstallAction.__tolls_installed:
+            if GlobalToolInstallAction.__tools_installed:
                 LOG.info("Skipping to update Amazon.Lambda.Tools install/update, since it is updated recently")
                 return
 
             try:
                 LOG.debug("Installing Amazon.Lambda.Tools Global Tool")
                 self.subprocess_dotnet.run(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
+                GlobalToolInstallAction.__tools_installed = True
             except DotnetCLIExecutionError as ex:
                 LOG.debug("Error installing probably due to already installed. Attempt to update to latest version.")
                 try:
                     self.subprocess_dotnet.run(
                         ["tool", "update", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
+                    GlobalToolInstallAction.__tools_installed = True
                 except DotnetCLIExecutionError as ex:
                     raise ActionFailedError(
                         "Error configuring the Amazon.Lambda.Tools .NET Core Global Tool: " + str(ex))
-            GlobalToolInstallAction.__tolls_installed = True
 
 
 class RunPackageAction(BaseAction):

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -4,14 +4,13 @@ from unittest import TestCase
 from mock import patch, call
 import os
 import platform
-from multiprocessing import Process
 import asyncio
 
 from aws_lambda_builders.actions import ActionFailedError
 from aws_lambda_builders.workflows.dotnet_clipackage.dotnetcli import DotnetCLIExecutionError
 from aws_lambda_builders.workflows.dotnet_clipackage.actions import GlobalToolInstallAction, RunPackageAction
 
-
+@patch.object(GlobalToolInstallAction, "_GlobalToolInstallAction__tools_installed", False)
 class TestGlobalToolInstallAction(TestCase):
     @patch("aws_lambda_builders.workflows.dotnet_clipackage.dotnetcli.SubprocessDotnetCLI")
     def setUp(self, MockSubprocessDotnetCLI):

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -10,6 +10,7 @@ from aws_lambda_builders.actions import ActionFailedError
 from aws_lambda_builders.workflows.dotnet_clipackage.dotnetcli import DotnetCLIExecutionError
 from aws_lambda_builders.workflows.dotnet_clipackage.actions import GlobalToolInstallAction, RunPackageAction
 
+
 @patch.object(GlobalToolInstallAction, "_GlobalToolInstallAction__tools_installed", False)
 class TestGlobalToolInstallAction(TestCase):
     @patch("aws_lambda_builders.workflows.dotnet_clipackage.dotnetcli.SubprocessDotnetCLI")
@@ -56,15 +57,14 @@ class TestGlobalToolInstallAction(TestCase):
             func()
 
         async_results = [
-            asyncio.get_event_loop().run_until_complete(async_wrapper(action.execute))
-            for action in actions
+            asyncio.get_event_loop().run_until_complete(async_wrapper(action.execute)) for action in actions
         ]
 
         async_wrapper(lambda: asyncio.gather(*async_results))
 
-        self.subprocess_dotnet.assert_has_calls([
-            call.run(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
-        ])
+        self.subprocess_dotnet.assert_has_calls(
+            [call.run(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])]
+        )
 
 
 class TestRunPackageAction(TestCase):

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from concurrent.futures import ThreadPoolExecutor
-from mock import patch, call
+from mock import patch
 import os
 import platform
 
@@ -46,21 +46,18 @@ class TestGlobalToolInstallAction(TestCase):
         self.assertRaises(ActionFailedError, action.execute)
 
     def test_global_tool_parallel(self):
-        executor = ThreadPoolExecutor()
-
         actions = [
             GlobalToolInstallAction(self.subprocess_dotnet),
             GlobalToolInstallAction(self.subprocess_dotnet),
             GlobalToolInstallAction(self.subprocess_dotnet),
         ]
 
-        for action in actions:
-            executor.submit(action.execute)
+        with ThreadPoolExecutor() as executor:
+            for action in actions:
+                executor.submit(action.execute)
 
-        executor.shutdown()
-
-        self.subprocess_dotnet.assert_has_calls(
-            [call.run(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])]
+        self.subprocess_dotnet.run.assert_called_once_with(
+            ["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
         )
 
 


### PR DESCRIPTION
https://github.com/aws/aws-lambda-builders/issues/211

*Description of changes:*
This change is adding a lock and an installation flag to GlobalToolInstallAction, to run it only once when it has run in a parallel build process.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
