### PR TITLE
fix: Python Workflow with Incorrect Environ

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,6 +64,7 @@ for:
     - "choco install bzr"
     - "choco install dep"
     - setx PATH "C:\go\bin;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
+    - "refreshenv"
     - "go version"
     - "go env"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,6 @@ for:
     - "choco install dep"
     - setx PATH "C:\Program Files\Go;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
     - setx GOROOT "C:\Program Files\Go"
-    - "refreshenv"
     - "go version"
     - "go env"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,6 +64,7 @@ for:
     - "choco install bzr"
     - "choco install dep"
     - setx PATH "C:\Program Files\Go;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
+    - setx GOROOT "C:\Program Files\Go"
     - "refreshenv"
     - "go version"
     - "go env"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,7 +63,7 @@ for:
     - "choco install golang"
     - "choco install bzr"
     - "choco install dep"
-    - setx PATH "C:\go\bin;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
+    - setx PATH "C:\Program Files\Go;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
     - "refreshenv"
     - "go version"
     - "go env"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,7 +63,7 @@ for:
     - "choco install golang"
     - "choco install bzr"
     - "choco install dep"
-    - setx PATH "C:\Program Files\Go;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
+    - setx PATH "C:\Program Files\Go\bin;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
     - setx GOROOT "C:\Program Files\Go"
     - "go version"
     - "go env"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,11 +60,10 @@ for:
 
     # setup go
     - rmdir c:\go /s /q
-    - "choco install golang"
+    - "choco install golang --version 1.15.7"
     - "choco install bzr"
     - "choco install dep"
-    - setx PATH "C:\Program Files\Go\bin;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
-    - setx GOROOT "C:\Program Files\Go"
+    - setx PATH "C:\go\bin;C:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial;%PATH%;"
     - "go version"
     - "go env"
 

--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -7,7 +7,7 @@ from aws_lambda_builders.workflows.python_pip.utils import OSUtils
 def pip_import_string(python_exe):
     os_utils = OSUtils()
     cmd = [python_exe, "-c", "import pip; print(pip.__version__)"]
-    p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe)
+    p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe, env=os_utils.original_environ())
     stdout, stderr = p.communicate()
     if not p.returncode == 0:
         raise MissingPipError(python_path=python_exe)

--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -494,7 +494,9 @@ class SDistMetadataFetcher(object):
         cmd = [sys.executable, "-c", script, "--no-user-cfg", "egg_info", "--egg-base", "egg-info"]
         egg_info_dir = self._osutils.joinpath(package_dir, "egg-info")
         self._osutils.makedirs(egg_info_dir)
-        p = subprocess.Popen(cmd, cwd=package_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self._osutils.original_environ())
+        p = subprocess.Popen(
+            cmd, cwd=package_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self._osutils.original_environ()
+        )
         p.communicate()
         info_contents = self._osutils.get_directory_contents(egg_info_dir)
         pkg_info_path = self._osutils.joinpath(egg_info_dir, info_contents[0], "PKG-INFO")

--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -494,7 +494,7 @@ class SDistMetadataFetcher(object):
         cmd = [sys.executable, "-c", script, "--no-user-cfg", "egg_info", "--egg-base", "egg-info"]
         egg_info_dir = self._osutils.joinpath(package_dir, "egg-info")
         self._osutils.makedirs(egg_info_dir)
-        p = subprocess.Popen(cmd, cwd=package_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(cmd, cwd=package_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self._osutils.original_environ())
         p.communicate()
         info_contents = self._osutils.get_directory_contents(egg_info_dir)
         pkg_info_path = self._osutils.joinpath(egg_info_dir, info_contents[0], "PKG-INFO")
@@ -535,7 +535,7 @@ class SubprocessPip(object):
 
     def main(self, args, env_vars=None, shim=None):
         if env_vars is None:
-            env_vars = self._osutils.environ()
+            env_vars = self._osutils.original_environ()
         if shim is None:
             shim = ""
         run_pip = ("import sys; %s; sys.exit(main(%s))") % (self._import_string, args)

--- a/aws_lambda_builders/workflows/python_pip/utils.py
+++ b/aws_lambda_builders/workflows/python_pip/utils.py
@@ -10,6 +10,7 @@ import tempfile
 import shutil
 import tarfile
 import subprocess
+import platform
 
 
 class OSUtils(object):
@@ -19,14 +20,15 @@ class OSUtils(object):
     def original_environ(self):
         # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
         env = dict(os.environ)
-        lp_key = "LD_LIBRARY_PATH"
-        original_lp = env.get(lp_key + "_ORIG")
-        if original_lp is not None:
-            env[lp_key] = original_lp
-        else:
-            # This happens when LD_LIBRARY_PATH was not set.
-            # Remove the env var as a last resort:
-            env.pop(lp_key, None)
+        if platform.system().lower() == "linux":
+            lp_key = "LD_LIBRARY_PATH"
+            original_lp = env.get(lp_key + "_ORIG")
+            if original_lp is not None:
+                env[lp_key] = original_lp
+            else:
+                # This happens when LD_LIBRARY_PATH was not set.
+                # Remove the env var as a last resort:
+                env.pop(lp_key, None)
         return env
 
     def file_exists(self, filename):

--- a/aws_lambda_builders/workflows/python_pip/utils.py
+++ b/aws_lambda_builders/workflows/python_pip/utils.py
@@ -10,7 +10,7 @@ import tempfile
 import shutil
 import tarfile
 import subprocess
-import platform
+import sys
 
 
 class OSUtils(object):
@@ -20,7 +20,7 @@ class OSUtils(object):
     def original_environ(self):
         # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
         env = dict(os.environ)
-        if platform.system().lower() == "linux":
+        if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
             lp_key = "LD_LIBRARY_PATH"
             original_lp = env.get(lp_key + "_ORIG")
             if original_lp is not None:
@@ -29,6 +29,7 @@ class OSUtils(object):
                 # This happens when LD_LIBRARY_PATH was not set.
                 # Remove the env var as a last resort:
                 env.pop(lp_key, None)
+
         return env
 
     def file_exists(self, filename):

--- a/aws_lambda_builders/workflows/python_pip/utils.py
+++ b/aws_lambda_builders/workflows/python_pip/utils.py
@@ -20,6 +20,7 @@ class OSUtils(object):
     def original_environ(self):
         # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
         env = dict(os.environ)
+        # Check whether running as a PyInstaller binary
         if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
             lp_key = "LD_LIBRARY_PATH"
             original_lp = env.get(lp_key + "_ORIG")

--- a/aws_lambda_builders/workflows/python_pip/utils.py
+++ b/aws_lambda_builders/workflows/python_pip/utils.py
@@ -27,6 +27,7 @@ class OSUtils(object):
             # This happens when LD_LIBRARY_PATH was not set.
             # Remove the env var as a last resort:
             env.pop(lp_key, None)
+        return env
 
     def file_exists(self, filename):
         return os.path.isfile(filename)

--- a/aws_lambda_builders/workflows/python_pip/utils.py
+++ b/aws_lambda_builders/workflows/python_pip/utils.py
@@ -17,10 +17,10 @@ class OSUtils(object):
         return os.environ
 
     def original_environ(self):
-        #https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
+        # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
         env = dict(os.environ)
         lp_key = "LD_LIBRARY_PATH"
-        original_lp = env.get(lp_key + '_ORIG')
+        original_lp = env.get(lp_key + "_ORIG")
         if original_lp is not None:
             env[lp_key] = original_lp
         else:

--- a/aws_lambda_builders/workflows/python_pip/utils.py
+++ b/aws_lambda_builders/workflows/python_pip/utils.py
@@ -16,6 +16,18 @@ class OSUtils(object):
     def environ(self):
         return os.environ
 
+    def original_environ(self):
+        #https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
+        env = dict(os.environ)
+        lp_key = "LD_LIBRARY_PATH"
+        original_lp = env.get(lp_key + '_ORIG')
+        if original_lp is not None:
+            env[lp_key] = original_lp
+        else:
+            # This happens when LD_LIBRARY_PATH was not set.
+            # Remove the env var as a last resort:
+            env.pop(lp_key, None)
+
     def file_exists(self, filename):
         return os.path.isfile(filename)
 

--- a/aws_lambda_builders/workflows/python_pip/validator.py
+++ b/aws_lambda_builders/workflows/python_pip/validator.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 
 from aws_lambda_builders.exceptions import MisMatchRuntimeError
+from .utils import OSUtils
 
 LOG = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class PythonRuntimeValidator(object):
 
         cmd = self._validate_python_cmd(runtime_path)
 
-        p = subprocess.Popen(cmd, cwd=os.getcwd(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(cmd, cwd=os.getcwd(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=OSUtils().original_environ())
         p.communicate()
         if p.returncode != 0:
             raise MisMatchRuntimeError(language=self.language, required_runtime=self.runtime, runtime_path=runtime_path)

--- a/aws_lambda_builders/workflows/python_pip/validator.py
+++ b/aws_lambda_builders/workflows/python_pip/validator.py
@@ -40,7 +40,9 @@ class PythonRuntimeValidator(object):
 
         cmd = self._validate_python_cmd(runtime_path)
 
-        p = subprocess.Popen(cmd, cwd=os.getcwd(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=OSUtils().original_environ())
+        p = subprocess.Popen(
+            cmd, cwd=os.getcwd(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=OSUtils().original_environ()
+        )
         p.communicate()
         if p.returncode != 0:
             raise MisMatchRuntimeError(language=self.language, required_runtime=self.runtime, runtime_path=runtime_path)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-builders/issues/224

*Description of changes:*
Patches the LB_LIBRARY_PATH envar and passes the original one to all popens in Python workflow.
This is required as PyInstaller changes LB_LIBRARY_PATH and affects its subprocesses.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
