### PR TITLE
Fix Go debug mode

### DIFF
--- a/aws_lambda_builders/workflows/go_modules/builder.py
+++ b/aws_lambda_builders/workflows/go_modules/builder.py
@@ -49,7 +49,7 @@ class GoModulesBuilder(object):
         cmd = [runtime_path, "build"]
         if self.mode and self.mode.lower() == BuildMode.DEBUG:
             LOG.debug("Debug build requested: Setting configuration to Debug")
-            cmd += ["-gcflags='all=-N -l'"]
+            cmd += ["-gcflags", "all=-N -l"]
         cmd += ["-o", output_path, source_dir_path]
 
         p = self.osutils.popen(cmd, cwd=source_dir_path, env=env, stdout=self.osutils.pipe, stderr=self.osutils.pipe)

--- a/tests/unit/workflows/go_modules/test_builder.py
+++ b/tests/unit/workflows/go_modules/test_builder.py
@@ -54,7 +54,7 @@ class TestGoBuilder(TestCase):
         self.under_test = GoModulesBuilder(self.osutils, self.binaries, "Debug")
         self.under_test.build("source_dir", "output_path")
         self.osutils.popen.assert_called_with(
-            ["/path/to/go", "build", "-gcflags='all=-N -l'", "-o", "output_path", "source_dir"],
+            ["/path/to/go", "build", "-gcflags", "all=-N -l", "-o", "output_path", "source_dir"],
             cwd="source_dir",
             env={"GOOS": "linux", "GOARCH": "amd64"},
             stderr="PIPE",


### PR DESCRIPTION
Compiling Go binaries without optimizations was not working. This is because "-gcflags='all=-N -l'" is not actually a valid argument to be passed to the executable. The equal sign should be treated as an argument separator, so a shell would parse this to  "-gcflags" and "all=-N -l".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
