### PR TITLE
docs: Guidance on integrating with Lambda Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,14 @@ Lambda Builders currently contains the following workflows
 
 Lambda Builders is the brains behind the `sam build` command from [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli)
 
+### Integrating with Lambda Builders
+
+Lambda Builders is a Python library.
+It additionally exposes a JSON-RPC 2.0 interface to use from other languages.
+
+If you intend to integrate with Lambda Builders,
+check out [this section of the DESIGN DOCUMENT](DESIGN.md#builders-library).
+
+### Contributing
+
 If you are a developer and interested in contributing, read the [DESIGN DOCUMENT](./DESIGN.md) to understand how this works.


### PR DESCRIPTION
*Issue #, if available:*

Solves #235 

*Description of changes:*

* Improved the main [design document](DESIGN.md)
  to explain integration via the JSON-RPC 2.0 interface
* Added a reference to the design document
  for developers intending to integrate to Lambda Builders


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
