### PR TITLE
Look for updated pip logging to detect directory links

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -596,7 +596,7 @@ class SubprocessPip(object):
 class PipRunner(object):
     """Wrapper around pip calls used by chalice."""
 
-    _LINK_IS_DIR_PATTERN = "Processing (.+?)\n  Link is a directory, ignoring download_dir"
+    _LINK_IS_DIR_PATTERN = "Not copying link to destination directory since it is a directory: file://(.+?)\n"
 
     def __init__(self, python_exe, pip, osutils=None):
         if osutils is None:
@@ -627,7 +627,7 @@ class PipRunner(object):
 
     def download_all_dependencies(self, requirements_filename, directory):
         """Download all dependencies as sdist or wheel."""
-        arguments = ["-r", requirements_filename, "--dest", directory, "--exists-action", "i"]
+        arguments = ["-r", requirements_filename, "--dest", directory, "--exists-action", "i", "-v"]
         rc, out, err = self._execute("download", arguments)
         # When downloading all dependencies we expect to get an rc of 0 back
         # since we are casting a wide net here letting pip have options about

--- a/requirements/python_pip.txt
+++ b/requirements/python_pip.txt
@@ -3,3 +3,6 @@
 # TODO: Consider moving this dependency directly into the `python_pip` workflow module
 setuptools
 wheel
+
+# see issue #246
+pip>=20.3

--- a/tests/functional/workflows/python_pip/test_packager.py
+++ b/tests/functional/workflows/python_pip/test_packager.py
@@ -211,7 +211,9 @@ class TestDependencyBuilder(object):
         pip, runner = pip_runner
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
-        pip.set_return_tuple(0, (b"Processing ../foo\n" b"  Link is a directory," b" ignoring download_dir"), b"")
+        pip.set_return_tuple(
+            0, (b"Not copying link to destination directory since it is a directory: file://../foo\n"), b""
+        )
         pip.wheels_to_build(
             expected_args=["--no-deps", "--wheel-dir", mock.ANY, "../foo"],
             wheels_to_build=["foo-1.2-cp36-none-any.whl"],
@@ -231,7 +233,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2-cp36-cp36m-manylinux1_x86_64.whl", "bar-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
         )
 
@@ -250,7 +252,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=[
                 "foo-1.2-cp33-abi3-manylinux1_x86_64.whl",
                 "bar-1.2-cp34-abi3-manylinux1_x86_64.whl",
@@ -274,7 +276,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
             whl_contents=["foo-1.2.data/purelib/foo/"],
         )
@@ -294,7 +296,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
             whl_contents=["foo-1.2.data/platlib/foo/"],
         )
@@ -316,7 +318,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
             whl_contents=["foo-1.2.data/platlib/foo/", "foo-1.2.data/purelib/bar/"],
         )
@@ -338,7 +340,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
             whl_contents=["foo/placeholder", "foo-1.2.data/data/bar/"],
         )
@@ -361,7 +363,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
             whl_contents=["foo/placeholder", "foo.1.2.data/includes/bar/"],
         )
@@ -384,7 +386,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
             whl_contents=["{package_name}/placeholder", "{data_dir}/scripts/bar/placeholder"],
         )
@@ -408,7 +410,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
             whl_contents=[
                 "{package_name}/placeholder",
@@ -432,7 +434,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=[
                 "foo-1.0-cp36-none-any.whl",
                 "bar-1.2-cp36-cp36m-manylinux1_x86_64.whl",
@@ -455,7 +457,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=[
                 "foo-1.2-cp36-cp36m-manylinux_2_12_x86_64.whl",
             ],
@@ -476,7 +478,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=[
                 "foo-1.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl",
             ],
@@ -497,7 +499,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=[
                 "foo-1.0-cp27-none-any.whl",
                 "bar-1.2-cp27-none-manylinux1_x86_64.whl",
@@ -519,7 +521,9 @@ class TestDependencyBuilder(object):
         pip, runner = pip_runner
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
-        pip.set_return_tuple(0, (b"Processing ../foo\n" b"  Link is a directory," b" ignoring download_dir"), b"")
+        pip.set_return_tuple(
+            0, (b"Not copying link to destination directory since it is a directory: file://../foo\n"), b""
+        )
         pip.wheels_to_build(
             expected_args=["--no-deps", "--wheel-dir", mock.ANY, "../foo"],
             wheels_to_build=["foo-1.2-cp36-cp36m-macosx_10_6_intel.whl"],
@@ -543,7 +547,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["baz-1.5-cp27-cp27m-linux_x86_64.whl"],
         )
 
@@ -565,7 +569,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["baz-1.5-cp14-cp14m-linux_x86_64.whl"],
         )
 
@@ -587,7 +591,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=[
                 "foo-1.2-cp36-cp36m-manylinux_2_12_x86_64.whl",
                 "bar-1.2-cp36-cp36m-manylinux_2_999_x86_64.whl",
@@ -617,7 +621,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.0-cp36-none-any.whl", "bar-1.2-cp36-cp36m-macosx_10_6_intel.whl"],
         )
         # Once the initial download has 1 incompatible whl file. The second,
@@ -653,7 +657,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["SQLAlchemy-1.1.18-cp36-cp36m-macosx_10_11_x86_64.whl"],
         )
         pip.packages_to_download(
@@ -686,7 +690,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2.zip", "bar-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
         )
         # Foo is built from and is pure python so it yields a compatible
@@ -710,7 +714,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2.zip", "bar-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
         )
         # foo is compiled since downloading it failed to get any wheels. And
@@ -744,7 +748,7 @@ class TestDependencyBuilder(object):
         # at all, and optional c speedups. The initial download will yield an
         # sdist since there were no wheels.
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2.zip"],
         )
 
@@ -788,7 +792,7 @@ class TestDependencyBuilder(object):
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
         pip.packages_to_download(
-            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i"],
+            expected_args=["-r", requirements_file, "--dest", mock.ANY, "--exists-action", "i", "-v"],
             packages=["foo-1.2.zip", "bar-1.2-cp36-cp36m-manylinux1_x86_64.whl"],
         )
         pip.packages_to_download(

--- a/tests/integration/workflows/python_pip/testdata-issue-246/setup.cfg
+++ b/tests/integration/workflows/python_pip/testdata-issue-246/setup.cfg
@@ -1,0 +1,16 @@
+[metadata]
+name = issue-246-code
+description = "Use src/ setup of a python project to demonstrate aws/aws-lambda-builders#246"
+version = 0.0.0
+
+[options]
+zip_safe = False
+packages = find:
+package_dir =
+    =src
+install_requires =
+    requests==2.23.0
+include_package_data = True
+
+[options.packages.find]
+where = src

--- a/tests/integration/workflows/python_pip/testdata-issue-246/setup.py
+++ b/tests/integration/workflows/python_pip/testdata-issue-246/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/tests/integration/workflows/python_pip/testdata-issue-246/src/issue_246_code/entrypoint.py
+++ b/tests/integration/workflows/python_pip/testdata-issue-246/src/issue_246_code/entrypoint.py
@@ -1,0 +1,2 @@
+def handler(event, ctx):
+    pass

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -218,7 +218,7 @@ class TestPipRunner(object):
 
         assert len(pip.calls) == 1
         call = pip.calls[0]
-        assert call.args == ["download", "-r", "requirements.txt", "--dest", "directory", "--exists-action", "i"]
+        assert call.args == ["download", "-r", "requirements.txt", "--dest", "directory", "--exists-action", "i", "-v"]
         assert call.env_vars is None
         assert call.shim is None
 
@@ -253,7 +253,9 @@ class TestPipRunner(object):
 
     def test_does_find_local_directory(self, pip_factory):
         pip, runner = pip_factory()
-        pip.add_return((0, (b"Processing ../local-dir\n" b"  Link is a directory," b" ignoring download_dir"), b""))
+        pip.add_return(
+            (0, (b"Not copying link to destination directory since it is a directory: file://../local-dir\n"), b"")
+        )
         runner.download_all_dependencies("requirements.txt", "directory")
         assert len(pip.calls) == 2
         assert pip.calls[1].args == ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-dir"]
@@ -264,13 +266,13 @@ class TestPipRunner(object):
             (
                 0,
                 (
-                    b"Processing ../local-dir-1\n"
-                    b"  Link is a directory,"
-                    b" ignoring download_dir"
+                    b"Not copying link to destination"
+                    b" directory since it is a directory:"
+                    b" file://../local-dir-1\n"
                     b"\nsome pip output...\n"
-                    b"Processing ../local-dir-2\n"
-                    b"  Link is a directory,"
-                    b" ignoring download_dir"
+                    b"Not copying link to destination"
+                    b" directory since it is a directory:"
+                    b" file://../local-dir-2\n"
                 ),
                 b"",
             )


### PR DESCRIPTION
*Issue #, if available:*
Fixes #246 

*Background*
Per #246, the `pip` logging that aws-lambda-builders previously used to detect directory links (i.e. local packages) has been removed. It was replaced by another more detailed piece of logging that only appears when `pip download` is invoked with verbosity (`-v`).

Without this, the previous behavior of invoking `pip wheel` on the local links in question no longer happens. The upshot is that python projects with a `src/` setup would no longer be properly installed to the artifact directory.

*Description of changes:*
* Add an integration test ensuring that a python project with a `src/` setup is installed correctly.
* Update the regex used to scan pip output.
* Add verbosity to `pip download` arguments to ensure the output corresponding to the new regex will be logged.
* Enforce the regex's assumption of what the logging will look like by ensuring an up-to-date version of pip in the project `requirements`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
