### PR TITLE
fix: Pip not resolving local packages

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -596,6 +596,9 @@ class SubprocessPip(object):
 class PipRunner(object):
     """Wrapper around pip calls used by chalice."""
 
+    # Update regex pattern to correspond with the updated output from pip
+    # Specific commit:
+    # https://github.com/pypa/pip/commit/b28e2c4928cc62d90b738a4613886fb1e2ad6a81#diff-5225c8e359020adb25dfc8c7a505950fd649c6c5775789c6f6517f7913f94542L529
     _LINK_IS_DIR_PATTERNS = ["Processing (.+?)\n"]
 
     def __init__(self, python_exe, pip, osutils=None):

--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -596,7 +596,7 @@ class SubprocessPip(object):
 class PipRunner(object):
     """Wrapper around pip calls used by chalice."""
 
-    _LINK_IS_DIR_PATTERNS = ["Processing (.+?)\n  Link is a directory, ignoring download_dir", "Processing (.+?)\n"]
+    _LINK_IS_DIR_PATTERNS = ["Processing (.+?)\n"]
 
     def __init__(self, python_exe, pip, osutils=None):
         if osutils is None:

--- a/tests/functional/workflows/python_pip/test_packager.py
+++ b/tests/functional/workflows/python_pip/test_packager.py
@@ -211,7 +211,7 @@ class TestDependencyBuilder(object):
         pip, runner = pip_runner
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
-        pip.set_return_tuple(0, (b"Processing ../foo\n" b"  Link is a directory," b" ignoring download_dir"), b"")
+        pip.set_return_tuple(0, b"Processing ../foo\n", b"")
         pip.wheels_to_build(
             expected_args=["--no-deps", "--wheel-dir", mock.ANY, "../foo"],
             wheels_to_build=["foo-1.2-cp36-none-any.whl"],
@@ -519,7 +519,7 @@ class TestDependencyBuilder(object):
         pip, runner = pip_runner
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
-        pip.set_return_tuple(0, (b"Processing ../foo\n" b"  Link is a directory," b" ignoring download_dir"), b"")
+        pip.set_return_tuple(0, b"Processing ../foo\n", b"")
         pip.wheels_to_build(
             expected_args=["--no-deps", "--wheel-dir", mock.ANY, "../foo"],
             wheels_to_build=["foo-1.2-cp36-cp36m-macosx_10_6_intel.whl"],

--- a/tests/functional/workflows/python_pip/test_packager.py
+++ b/tests/functional/workflows/python_pip/test_packager.py
@@ -211,7 +211,7 @@ class TestDependencyBuilder(object):
         pip, runner = pip_runner
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
-        pip.set_return_tuple(0, b"Processing ../foo\n", b"")
+        pip.set_return_tuple(0, (b"Processing ../foo\n" b"  Link is a directory," b" ignoring download_dir"), b"")
         pip.wheels_to_build(
             expected_args=["--no-deps", "--wheel-dir", mock.ANY, "../foo"],
             wheels_to_build=["foo-1.2-cp36-none-any.whl"],
@@ -519,7 +519,7 @@ class TestDependencyBuilder(object):
         pip, runner = pip_runner
         appdir, builder = self._make_appdir_and_dependency_builder(reqs, tmpdir, runner)
         requirements_file = os.path.join(appdir, "requirements.txt")
-        pip.set_return_tuple(0, b"Processing ../foo\n", b"")
+        pip.set_return_tuple(0, (b"Processing ../foo\n" b"  Link is a directory," b" ignoring download_dir"), b"")
         pip.wheels_to_build(
             expected_args=["--no-deps", "--wheel-dir", mock.ANY, "../foo"],
             wheels_to_build=["foo-1.2-cp36-cp36m-macosx_10_6_intel.whl"],

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -85,21 +85,25 @@ class TestPythonPipWorkflow(TestCase):
             )
 
     def test_must_resolve_local_dependency(self):
-        dependency_source_dir = os.path.join(self.source_dir, "local-dependencies", "hello_world")
-        dependency_local_manifest = os.path.join(dependency_source_dir, "requirements.txt")
-        path_to_package = os.path.join(self.source_dir, "local-dependencies", "some_package")
+        source_dir = os.path.join(self.source_dir, "local-dependencies")
+        manifest = os.path.join(source_dir, "requirements.txt")
+        path_to_package = os.path.join(self.source_dir, "local-dependencies")
         # pip resolves dependencies in requirements files relative to the current working directory
         # need to make sure the correct path is used in the requirements file locally and in CI
-        with open(dependency_local_manifest, "w") as f:
+        with open(manifest, "w") as f:
             f.write(str(path_to_package))
-        self.builder.build(
-            dependency_source_dir, self.artifacts_dir, self.scratch_dir, dependency_local_manifest, runtime=self.runtime
-        )
-        expected_files = {"LocalPackage", "LocalPackage-0.0.0.dist-info", "__init__.py", "requirements.txt"}
+        self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir, manifest, runtime=self.runtime)
+        expected_files = {
+            "local_package",
+            "local_package-0.0.0.dist-info",
+            "requests",
+            "requests-2.23.0.dist-info",
+            "setup.py",
+            "requirements.txt",
+        }
         output_files = set(os.listdir(self.artifacts_dir))
-        if os.path.exists(dependency_local_manifest):
-            os.remove(dependency_local_manifest)
-        self.assertEqual(expected_files, output_files)
+        for f in expected_files:
+            self.assertIn(f, output_files)
 
     def test_must_fail_to_resolve_dependencies(self):
 

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -78,6 +78,16 @@ class TestPythonPipWorkflow(TestCase):
                 self.source_dir, self.artifacts_dir, self.scratch_dir, self.manifest_path_valid, runtime="python2.8"
             )
 
+    def test_must_resolve_local_dependency(self):
+        dependency_source_dir = os.path.join(self.source_dir, "local-dependencies", "hello_world")
+        dependency_local_manifest = os.path.join(dependency_source_dir, "requirements.txt")
+        self.builder.build(
+            dependency_source_dir, self.artifacts_dir, self.scratch_dir, dependency_local_manifest, runtime=self.runtime
+        )
+        expected_files = {"LocalPackage", "LocalPackage-0.0.0.dist-info", "__init__.py", "requirements.txt"}
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)
+
     def test_must_fail_to_resolve_dependencies(self):
 
         with self.assertRaises(WorkflowFailedError) as ctx:

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -27,7 +27,13 @@ class TestPythonPipWorkflow(TestCase):
         self.manifest_path_valid = os.path.join(self.TEST_DATA_FOLDER, "requirements-numpy.txt")
         self.manifest_path_invalid = os.path.join(self.TEST_DATA_FOLDER, "requirements-invalid.txt")
 
-        self.test_data_files = {"__init__.py", "main.py", "requirements-invalid.txt", "requirements-numpy.txt"}
+        self.test_data_files = {
+            "__init__.py",
+            "main.py",
+            "requirements-invalid.txt",
+            "requirements-numpy.txt",
+            "local-dependencies",
+        }
 
         self.builder = LambdaBuilder(language="python", dependency_manager="pip", application_framework=None)
         self.runtime = "{language}{major}.{minor}".format(
@@ -81,11 +87,18 @@ class TestPythonPipWorkflow(TestCase):
     def test_must_resolve_local_dependency(self):
         dependency_source_dir = os.path.join(self.source_dir, "local-dependencies", "hello_world")
         dependency_local_manifest = os.path.join(dependency_source_dir, "requirements.txt")
+        path_to_package = os.path.join(self.source_dir, "local-dependencies", "some_package")
+        # pip resolves dependencies in requirements files relative to the current working directory
+        # need to make sure the correct path is used in the requirements file locally and in CI
+        with open(dependency_local_manifest, "w") as f:
+            f.write(str(path_to_package))
         self.builder.build(
             dependency_source_dir, self.artifacts_dir, self.scratch_dir, dependency_local_manifest, runtime=self.runtime
         )
         expected_files = {"LocalPackage", "LocalPackage-0.0.0.dist-info", "__init__.py", "requirements.txt"}
         output_files = set(os.listdir(self.artifacts_dir))
+        if os.path.exists(dependency_local_manifest):
+            os.remove(dependency_local_manifest)
         self.assertEqual(expected_files, output_files)
 
     def test_must_fail_to_resolve_dependencies(self):

--- a/tests/integration/workflows/python_pip/testdata/local-dependencies/hello_world/requirements.txt
+++ b/tests/integration/workflows/python_pip/testdata/local-dependencies/hello_world/requirements.txt
@@ -1,0 +1,1 @@
+./testdata/local-dependencies/some_package

--- a/tests/integration/workflows/python_pip/testdata/local-dependencies/hello_world/requirements.txt
+++ b/tests/integration/workflows/python_pip/testdata/local-dependencies/hello_world/requirements.txt
@@ -1,1 +1,0 @@
-./testdata/local-dependencies/some_package

--- a/tests/integration/workflows/python_pip/testdata/local-dependencies/setup.cfg
+++ b/tests/integration/workflows/python_pip/testdata/local-dependencies/setup.cfg
@@ -1,0 +1,16 @@
+[metadata]
+name = local_package
+description = "Use src/ setup of a python project to demonstrate local package resolution"
+version = 0.0.0
+
+[options]
+zip_safe = False
+packages = find:
+package_dir =
+    =src
+install_requires =
+    requests==2.23.0
+include_package_data = True
+
+[options.packages.find]
+where = src

--- a/tests/integration/workflows/python_pip/testdata/local-dependencies/setup.py
+++ b/tests/integration/workflows/python_pip/testdata/local-dependencies/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/tests/integration/workflows/python_pip/testdata/local-dependencies/some_package/setup.py
+++ b/tests/integration/workflows/python_pip/testdata/local-dependencies/some_package/setup.py
@@ -1,6 +1,0 @@
-from setuptools import find_packages, setup
-
-setup(
-    name="LocalPackage",
-    packages=find_packages(),
-)

--- a/tests/integration/workflows/python_pip/testdata/local-dependencies/some_package/setup.py
+++ b/tests/integration/workflows/python_pip/testdata/local-dependencies/some_package/setup.py
@@ -1,0 +1,6 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="LocalPackage",
+    packages=find_packages(),
+)

--- a/tests/integration/workflows/python_pip/testdata/local-dependencies/src/local_package/entrypoint.py
+++ b/tests/integration/workflows/python_pip/testdata/local-dependencies/src/local_package/entrypoint.py
@@ -1,0 +1,2 @@
+def handler(event, ctx):
+    pass

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -253,7 +253,7 @@ class TestPipRunner(object):
 
     def test_does_find_local_directory(self, pip_factory):
         pip, runner = pip_factory()
-        pip.add_return((0, (b"Processing ../local-dir\n" b"  Link is a directory," b" ignoring download_dir"), b""))
+        pip.add_return((0, b"Processing ../local-dir\n", b""))
         runner.download_all_dependencies("requirements.txt", "directory")
         assert len(pip.calls) == 2
         assert pip.calls[1].args == ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-dir"]
@@ -265,12 +265,8 @@ class TestPipRunner(object):
                 0,
                 (
                     b"Processing ../local-dir-1\n"
-                    b"  Link is a directory,"
-                    b" ignoring download_dir"
                     b"\nsome pip output...\n"
                     b"Processing ../local-dir-2\n"
-                    b"  Link is a directory,"
-                    b" ignoring download_dir"
                     b"Processing ../local-dir-3\n"
                 ),
                 b"",

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -267,6 +267,8 @@ class TestPipRunner(object):
                     b"Processing ../local-dir-1\n"
                     b"\nsome pip output...\n"
                     b"Processing ../local-dir-2\n"
+                    b"  Link is a directory,"
+                    b" ignoring download_dir"
                     b"Processing ../local-dir-3\n"
                 ),
                 b"",

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -271,14 +271,17 @@ class TestPipRunner(object):
                     b"Processing ../local-dir-2\n"
                     b"  Link is a directory,"
                     b" ignoring download_dir"
+                    b"Processing ../local-dir-3\n"
                 ),
                 b"",
             )
         )
         runner.download_all_dependencies("requirements.txt", "directory")
-        assert len(pip.calls) == 3
-        assert pip.calls[1].args == ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-dir-1"]
-        assert pip.calls[2].args == ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-dir-2"]
+        pip_calls = [call.args for call in pip.calls]
+        assert len(pip.calls) == 4
+        assert ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-dir-1"] in pip_calls
+        assert ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-dir-2"] in pip_calls
+        assert ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-dir-3"] in pip_calls
 
     def test_raise_no_such_package_error(self, pip_factory):
         pip, runner = pip_factory()


### PR DESCRIPTION
*Which issue(s) does this change fix?*
https://github.com/aws/aws-sam-cli/issues/2705

*Why is this change necessary?*
Fix local dependencies not being resolved by pip.

*How does it address the issue?*
Looks like [pip updated the output](https://github.com/pypa/pip/commit/b28e2c4928cc62d90b738a4613886fb1e2ad6a81#diff-5225c8e359020adb25dfc8c7a505950fd649c6c5775789c6f6517f7913f94542L529) that we try to string match, meaning we weren't catching local packages for newer versions of pip. 

This change adds multiple layers of regex matching to include both the old and new output format.

*What side effects does this change have?*

*Checklist:*

* [ ] Add input/output type hints to new functions/methods
* [ ] Write design document (Do I need to write a design document?) 
* [x] Write unit tests
* [ ] Write/update functional tests
* [x] Write/update integration tests
* [x] make pr passes
* [ ] make update-reproducible-reqs if dependencies were changed
* [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
