### PR TITLE
fix: don't filter files when copying dependencies to artifact folder for pip workflow

### DIFF
--- a/aws_lambda_builders/actions.py
+++ b/aws_lambda_builders/actions.py
@@ -187,7 +187,7 @@ class CleanUpAction(BaseAction):
 
         for name in targets:
             target_path = os.path.join(self.target_dir, name)
-            LOG.info("Clean up action: %s is deleted", str(target_path))
+            LOG.debug("Clean up action: %s is deleted", str(target_path))
 
             if os.path.isdir(target_path):
                 shutil.rmtree(target_path)

--- a/aws_lambda_builders/workflows/python_pip/workflow.py
+++ b/aws_lambda_builders/workflows/python_pip/workflow.py
@@ -105,7 +105,8 @@ class PythonPipWorkflow(BaseWorkflow):
         # if combine_dependencies is false, will not copy the dependencies from dependencies folder to artifact
         # folder
         if self.dependencies_dir and self.combine_dependencies:
-            self.actions.append(CopySourceAction(self.dependencies_dir, artifacts_dir, excludes=self.EXCLUDED_FILES))
+            # when copying downloaded dependencies back to artifacts folder, don't exclude anything
+            self.actions.append(CopySourceAction(self.dependencies_dir, artifacts_dir))
 
         self.actions.append(CopySourceAction(source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES))
 

--- a/tests/unit/workflows/python_pip/test_workflow.py
+++ b/tests/unit/workflows/python_pip/test_workflow.py
@@ -69,6 +69,8 @@ class TestPythonPipWorkflow(TestCase):
         self.assertIsInstance(self.workflow.actions[1], PythonPipBuildAction)
         self.assertIsInstance(self.workflow.actions[2], CopySourceAction)
         self.assertIsInstance(self.workflow.actions[3], CopySourceAction)
+        # check copying dependencies does not have any exclude
+        self.assertEqual(self.workflow.actions[2].excludes, [])
 
     def test_workflow_sets_up_actions_without_download_dependencies_without_dependencies_dir(self):
         osutils_mock = Mock(spec=self.osutils)


### PR DESCRIPTION
Default filtering is omitting native libraries during copy operation. We shouldn't be using any `excludes` flag for that action.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
