### PR TITLE
fix: Updated TestJavaMoveDependenciesAction to Include lib Folder

### DIFF
--- a/aws_lambda_builders/workflows/java/actions.py
+++ b/aws_lambda_builders/workflows/java/actions.py
@@ -59,7 +59,8 @@ class JavaMoveDependenciesAction(BaseAction):
         Move the entire lib directory from artifact folder to dependencies folder
         """
         try:
+            dependencies_lib_dir = os.path.join(self.dependencies_dir, "lib")
             lib_folder = os.path.join(self.artifacts_dir, "lib")
-            self.os_utils.move(lib_folder, self.dependencies_dir)
+            self.os_utils.move(lib_folder, dependencies_lib_dir)
         except Exception as ex:
             raise ActionFailedError(str(ex))

--- a/tests/unit/workflows/java/test_actions.py
+++ b/tests/unit/workflows/java/test_actions.py
@@ -46,7 +46,9 @@ class TestJavaMoveDependenciesAction(TestCase):
         action = JavaMoveDependenciesAction(self.artifacts_dir, self.dependencies_dir, self.os_utils)
         action.execute()
 
-        self.os_utils.move.assert_called_with(os.path.join(self.artifacts_dir, "lib"), self.dependencies_dir)
+        self.os_utils.move.assert_called_with(
+            os.path.join(self.artifacts_dir, "lib"), os.path.join(self.dependencies_dir, "lib")
+        )
 
     def test_error_in_artifact_copy_raises_action_error(self):
         self.os_utils.move.side_effect = Exception("scandir failed!")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/3429

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
