### PR TITLE
fix: log results of make build

### DIFF
--- a/aws_lambda_builders/workflows/custom_make/make.py
+++ b/aws_lambda_builders/workflows/custom_make/make.py
@@ -84,6 +84,9 @@ class SubProcessMake(object):
 
         out, err = p.communicate()
 
+        # Typically this type of information is logged to DEBUG, however, since the Make builder
+        # can be different per customer's use case, it is helpful to always log the output so
+        # developers can diagnose any issues.
         LOG.info(out.decode("utf8").strip())
 
         if p.returncode != 0:

--- a/aws_lambda_builders/workflows/custom_make/make.py
+++ b/aws_lambda_builders/workflows/custom_make/make.py
@@ -84,6 +84,8 @@ class SubProcessMake(object):
 
         out, err = p.communicate()
 
+        LOG.info(out.decode("utf8").strip())
+
         if p.returncode != 0:
             raise MakeExecutionError(message=err.decode("utf8").strip())
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The Make builder does not log anything to stdout when it executes the make command. This change logs the output of the make command so developers can see the results of the execution. This follows the same pattern that exists in the `dotnetcli` builder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
