### PR TITLE
Do not clone to scratch dir for typescript lamdas

### DIFF
--- a/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
@@ -2,9 +2,7 @@ from unittest import TestCase
 from mock import patch, call
 
 from aws_lambda_builders.actions import (
-    CopySourceAction,
     CleanUpAction,
-    CopyDependenciesAction,
     MoveDependenciesAction,
     LinkSourceAction,
 )
@@ -55,10 +53,9 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.assertEqual(len(workflow.actions), 3)
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], NodejsNpmInstallAction)
-        self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
+        self.assertEqual(len(workflow.actions), 2)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[1], EsbuildBundleAction)
         self.osutils.file_exists.assert_has_calls(
             [call("source/package-lock.json"), call("source/npm-shrinkwrap.json")]
         )
@@ -76,8 +73,8 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.osutils.popen.assert_called_with(["npm", "bin"], stdout="PIPE", stderr="PIPE", cwd="scratch_dir")
-        esbuild = workflow.actions[2]._subprocess_esbuild
+        self.osutils.popen.assert_called_with(["npm", "bin"], stdout="PIPE", stderr="PIPE", cwd="source")
+        esbuild = workflow.actions[1]._subprocess_esbuild
 
         self.assertIsInstance(esbuild, SubprocessEsbuild)
         self.assertEqual(esbuild.executable_search_paths, ["project/bin"])
@@ -96,8 +93,8 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.osutils.popen.assert_called_with(["npm", "bin"], stdout="PIPE", stderr="PIPE", cwd="scratch_dir")
-        esbuild = workflow.actions[2]._subprocess_esbuild
+        self.osutils.popen.assert_called_with(["npm", "bin"], stdout="PIPE", stderr="PIPE", cwd="source")
+        esbuild = workflow.actions[1]._subprocess_esbuild
         self.assertIsInstance(esbuild, SubprocessEsbuild)
         self.assertEqual(esbuild.executable_search_paths, ["project/bin", "other/bin"])
 
@@ -115,10 +112,9 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             options={"use_npm_ci": True},
         )
 
-        self.assertEqual(len(workflow.actions), 3)
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], NodejsNpmCIAction)
-        self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
+        self.assertEqual(len(workflow.actions), 2)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmCIAction)
+        self.assertIsInstance(workflow.actions[1], EsbuildBundleAction)
         self.osutils.file_exists.assert_has_calls([call("source/package-lock.json")])
 
     def test_workflow_uses_npm_ci_if_shrinkwrap_exists(self):
@@ -135,10 +131,9 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             options={"use_npm_ci": True},
         )
 
-        self.assertEqual(len(workflow.actions), 3)
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], NodejsNpmCIAction)
-        self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
+        self.assertEqual(len(workflow.actions), 2)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmCIAction)
+        self.assertIsInstance(workflow.actions[1], EsbuildBundleAction)
         self.osutils.file_exists.assert_has_calls(
             [call("source/package-lock.json"), call("source/npm-shrinkwrap.json")]
         )
@@ -156,10 +151,9 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.assertEqual(len(workflow.actions), 3)
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], NodejsNpmInstallAction)
-        self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
+        self.assertEqual(len(workflow.actions), 2)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[1], EsbuildBundleAction)
         self.osutils.file_exists.assert_has_calls(
             [call("source/package-lock.json"), call("source/npm-shrinkwrap.json")]
         )
@@ -203,10 +197,9 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.assertEqual(len(workflow.actions), 3)
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], NodejsNpmInstallAction)
-        self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
+        self.assertEqual(len(workflow.actions), 2)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[1], EsbuildBundleAction)
 
     def test_workflow_sets_up_esbuild_actions_without_download_dependencies_with_dependencies_dir_combine_deps(self):
         self.osutils.file_exists.return_value = True
@@ -223,10 +216,9 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.assertEqual(len(workflow.actions), 3)
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], LinkSourceAction)
-        self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
+        self.assertEqual(len(workflow.actions), 2)
+        self.assertIsInstance(workflow.actions[0], LinkSourceAction)
+        self.assertIsInstance(workflow.actions[1], EsbuildBundleAction)
 
     def test_workflow_sets_up_esbuild_actions_without_download_dependencies_with_dependencies_dir_no_combine_deps(self):
         self.osutils.file_exists.return_value = True
@@ -243,11 +235,10 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.assertEqual(len(workflow.actions), 4)
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], LinkSourceAction)
-        self.assertIsInstance(workflow.actions[2], EsbuildCheckVersionAction)
-        self.assertIsInstance(workflow.actions[3], EsbuildBundleAction)
+        self.assertEqual(len(workflow.actions), 3)
+        self.assertIsInstance(workflow.actions[0], LinkSourceAction)
+        self.assertIsInstance(workflow.actions[1], EsbuildCheckVersionAction)
+        self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
 
     def test_workflow_sets_up_esbuild_actions_with_download_dependencies_and_dependencies_dir(self):
 
@@ -264,14 +255,13 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.assertEqual(len(workflow.actions), 6)
+        self.assertEqual(len(workflow.actions), 5)
 
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], NodejsNpmInstallAction)
-        self.assertIsInstance(workflow.actions[2], CleanUpAction)
-        self.assertIsInstance(workflow.actions[3], EsbuildBundleAction)
-        self.assertIsInstance(workflow.actions[4], MoveDependenciesAction)
-        self.assertIsInstance(workflow.actions[5], LinkSourceAction)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[1], CleanUpAction)
+        self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
+        self.assertIsInstance(workflow.actions[3], MoveDependenciesAction)
+        self.assertIsInstance(workflow.actions[4], LinkSourceAction)
 
     def test_workflow_sets_up_esbuild_actions_with_download_dependencies_and_dependencies_dir_no_combine_deps(self):
         workflow = NodejsNpmEsbuildWorkflow(
@@ -286,11 +276,10 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[EXPERIMENTAL_FLAG_ESBUILD],
         )
 
-        self.assertEqual(len(workflow.actions), 6)
+        self.assertEqual(len(workflow.actions), 5)
 
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertIsInstance(workflow.actions[1], NodejsNpmInstallAction)
-        self.assertIsInstance(workflow.actions[2], CleanUpAction)
-        self.assertIsInstance(workflow.actions[3], EsbuildCheckVersionAction)
-        self.assertIsInstance(workflow.actions[4], EsbuildBundleAction)
-        self.assertIsInstance(workflow.actions[5], MoveDependenciesAction)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[1], CleanUpAction)
+        self.assertIsInstance(workflow.actions[2], EsbuildCheckVersionAction)
+        self.assertIsInstance(workflow.actions[3], EsbuildBundleAction)
+        self.assertIsInstance(workflow.actions[4], MoveDependenciesAction)


### PR DESCRIPTION
Source maps are broken in the Typescript Lamda are broken, causing line by line debugging to fail. My team spent a couple days completely stuck when developing a Typescript Lamda when we discovered it was a problem with the tool.

Since code gets copied to a "scratch dir" in /tmp esbuild points the sourcemap to the tmp directory.

```
{
  "version": 3,
  "sources": ["../../../../../../../../tmp/tmpdpzfnj5k/app.ts"],
  "sourcesContent": ["import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';\n\n/**\n *\n * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format\n * @param {Object} event - API Gateway Lambda Proxy Input Format\n *\n * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html\n * @returns {Object} object - API Gateway Lambda Proxy Output Format\n *\n */\n\nexport const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {\n    let response: APIGatewayProxyResult;\n    try {\n        response = {\n            statusCode: 200,\n            body: JSON.stringify({\n                message: 'hello world',\n            }),\n        };\n    } catch (err) {\n        console.log(err);\n        response = {\n            statusCode: 500,\n            body: JSON.stringify({\n                message: 'some error happened',\n            }),\n        };\n    }\n\n    return response;\n};\n"],
  "mappings": "yaAAA,wDAYO,GAAM,GAAgB,KAAO,IAAgE,CAChG,GAAI,GACJ,GAAI,CACA,EAAW,CACP,WAAY,IACZ,KAAM,KAAK,UAAU,CACjB,QAAS,aACb,CAAC,CACL,CACJ,OAAS,EAAP,CACE,QAAQ,IAAI,CAAG,EACf,EAAW,CACP,WAAY,IACZ,KAAM,KAAK,UAAU,CACjB,QAAS,qBACb,CAAC,CACL,CACJ,CAEA,MAAO,EACX",
  "names": []
}
```

The line-by-line debugger gets confused and skips through any breakpoints that were set.

PR does not clone the code into a scratch directory, compiles using the source directory into the build directory. I spent a lot of time looking for a flag inside esbuild that could point the sources content to another folder, but nothing existed.

Now, line-by-line debugging works.

```
{
  "version": 3,
  "sources": ["../../../hello-world/app.ts"],
  "sourcesContent": ["import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';\n\n/**\n *\n * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format\n * @param {Object} event - API Gateway Lambda Proxy Input Format\n *\n * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html\n * @returns {Object} object - API Gateway Lambda Proxy Output Format\n *\n */\n\nexport const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {\n    let response: APIGatewayProxyResult;\n    try {\n        response = {\n            statusCode: 200,\n            body: JSON.stringify({\n                message: 'hello world',\n            }),\n        };\n    } catch (err) {\n        console.log(err);\n        response = {\n            statusCode: 500,\n            body: JSON.stringify({\n                message: 'some error happened',\n            }),\n        };\n    }\n\n    return response;\n};\n"],
  "mappings": "yaAAA,wDAYO,GAAM,GAAgB,KAAO,IAAgE,CAChG,GAAI,GACJ,GAAI,CACA,EAAW,CACP,WAAY,IACZ,KAAM,KAAK,UAAU,CACjB,QAAS,aACb,CAAC,CACL,CACJ,OAAS,EAAP,CACE,QAAQ,IAAI,CAAG,EACf,EAAW,CACP,WAAY,IACZ,KAAM,KAAK,UAAU,CACjB,QAAS,qBACb,CAAC,CACL,CACJ,CAEA,MAAO,EACX",
  "names": []
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.