### PR TITLE
fix(path-resolver): Add additional binaries to python-pip workflow

### DIFF
--- a/aws_lambda_builders/exceptions.py
+++ b/aws_lambda_builders/exceptions.py
@@ -19,7 +19,7 @@ class MisMatchRuntimeError(LambdaBuilderError):
     MESSAGE = (
         "{language} executable found in your path does not "
         "match runtime. "
-        "\n Expected version: {required_runtime}, Found version: {runtime_path}. "
+        "\n Expected version: {required_runtime}, Found a different version at {runtime_path}. "
         "\n Possibly related: https://github.com/awslabs/aws-lambda-builders/issues/30"
     )
 

--- a/aws_lambda_builders/path_resolver.py
+++ b/aws_lambda_builders/path_resolver.py
@@ -6,10 +6,14 @@ from aws_lambda_builders.utils import which
 
 
 class PathResolver(object):
-    def __init__(self, binary, runtime, executable_search_paths=None):
+    def __init__(self, binary, runtime, additional_binaries=None, executable_search_paths=None):
         self.binary = binary
         self.runtime = runtime
         self.executables = [self.runtime, self.binary]
+        self.additional_binaries = additional_binaries
+        if isinstance(additional_binaries, list):
+            self.executables = self.executables + self.additional_binaries
+
         self.executable_search_paths = executable_search_paths
 
     def _which(self):

--- a/tests/unit/test_path_resolver.py
+++ b/tests/unit/test_path_resolver.py
@@ -9,11 +9,12 @@ from aws_lambda_builders.path_resolver import PathResolver
 
 class TestPathResolver(TestCase):
     def setUp(self):
-        self.path_resolver = PathResolver(runtime="chitti2.0", binary="chitti")
+        self.path_resolver = PathResolver(runtime="chitti2.0", binary="chitti", additional_binaries=["chitti2"])
 
     def test_inits(self):
         self.assertEqual(self.path_resolver.runtime, "chitti2.0")
         self.assertEqual(self.path_resolver.binary, "chitti")
+        self.assertEqual(self.path_resolver.executables, ["chitti2.0", "chitti", "chitti2"])
 
     def test_which_fails(self):
         with self.assertRaises(ValueError):

--- a/tests/unit/workflows/python_pip/test_workflow.py
+++ b/tests/unit/workflows/python_pip/test_workflow.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from parameterized import parameterized_class
 
 from aws_lambda_builders.actions import CopySourceAction, CleanUpAction, LinkSourceAction
+from aws_lambda_builders.path_resolver import PathResolver
 from aws_lambda_builders.workflows.python_pip.utils import OSUtils, EXPERIMENTAL_FLAG_BUILD_PERFORMANCE
 from aws_lambda_builders.workflows.python_pip.validator import PythonRuntimeValidator
 from aws_lambda_builders.workflows.python_pip.workflow import PythonPipBuildAction, PythonPipWorkflow
@@ -29,10 +30,13 @@ class TestPythonPipWorkflow(TestCase):
             "artifacts",
             "scratch_dir",
             "manifest",
-            runtime="python3.7",
+            runtime="python3.9",
             osutils=self.osutils_mock,
             experimental_flags=self.experimental_flags,
         )
+        self.python_major_version = "3"
+        self.python_minor_version = "9"
+        self.language = "python"
 
     def test_workflow_sets_up_actions(self):
         self.assertEqual(len(self.workflow.actions), 2)
@@ -46,7 +50,7 @@ class TestPythonPipWorkflow(TestCase):
             "artifacts",
             "scratch_dir",
             "manifest",
-            runtime="python3.7",
+            runtime="python3.9",
             osutils=self.osutils_mock,
             experimental_flags=self.experimental_flags,
         )
@@ -57,6 +61,18 @@ class TestPythonPipWorkflow(TestCase):
         for validator in self.workflow.get_validators():
             self.assertTrue(isinstance(validator, PythonRuntimeValidator))
 
+    def test_workflow_resolver(self):
+        for resolver in self.workflow.get_resolvers():
+            self.assertTrue(isinstance(resolver, PathResolver))
+            self.assertTrue(
+                resolver.executables,
+                [
+                    self.language,
+                    f"{self.language}{self.python_major_version}.{self.python_minor_version}",
+                    f"{self.language}{self.python_major_version}",
+                ],
+            )
+
     def test_workflow_sets_up_actions_without_download_dependencies_with_dependencies_dir(self):
         osutils_mock = Mock(spec=self.osutils)
         osutils_mock.file_exists.return_value = True
@@ -65,7 +81,7 @@ class TestPythonPipWorkflow(TestCase):
             "artifacts",
             "scratch_dir",
             "manifest",
-            runtime="python3.7",
+            runtime="python3.9",
             osutils=osutils_mock,
             dependencies_dir="dep",
             download_dependencies=False,
@@ -86,7 +102,7 @@ class TestPythonPipWorkflow(TestCase):
             "artifacts",
             "scratch_dir",
             "manifest",
-            runtime="python3.7",
+            runtime="python3.9",
             osutils=osutils_mock,
             dependencies_dir="dep",
             download_dependencies=True,
@@ -111,7 +127,7 @@ class TestPythonPipWorkflow(TestCase):
             "artifacts",
             "scratch_dir",
             "manifest",
-            runtime="python3.7",
+            runtime="python3.9",
             osutils=osutils_mock,
             dependencies_dir=None,
             download_dependencies=False,
@@ -128,7 +144,7 @@ class TestPythonPipWorkflow(TestCase):
             "artifacts",
             "scratch_dir",
             "manifest",
-            runtime="python3.7",
+            runtime="python3.9",
             osutils=osutils_mock,
             dependencies_dir="dep",
             download_dependencies=True,
@@ -147,7 +163,7 @@ class TestPythonPipWorkflow(TestCase):
             "artifacts",
             "scratch_dir",
             "manifest",
-            runtime="python3.7",
+            runtime="python3.9",
             architecture="ARM64",
             osutils=self.osutils_mock,
         )
@@ -155,7 +171,7 @@ class TestPythonPipWorkflow(TestCase):
             "artifacts",
             "scratch_dir",
             "manifest",
-            "python3.7",
+            "python3.9",
             None,
             binaries=ANY,
             architecture="ARM64",


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

* Lookup `python3` binary if the python runtime has a major version of 3.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
