### PR TITLE
feat: add custom working directory for custom build workflow

### DIFF
--- a/aws_lambda_builders/workflows/custom_make/actions.py
+++ b/aws_lambda_builders/workflows/custom_make/actions.py
@@ -52,7 +52,8 @@ class CustomMakeAction(BaseAction):
         :param build_logical_id: the lambda resource logical id that will be built by the custom action.
 
         :type working_directory: str
-        :param working_directory: path to the working directory where the Makefile will be executed.
+        :param working_directory: path to the working directory where the Makefile will be executed. Use the scratch_dir
+        as the working directory if the input working_directory is None
         """
         super(CustomMakeAction, self).__init__()
         self.artifacts_dir = artifacts_dir

--- a/aws_lambda_builders/workflows/custom_make/actions.py
+++ b/aws_lambda_builders/workflows/custom_make/actions.py
@@ -22,7 +22,16 @@ class CustomMakeAction(BaseAction):
     DESCRIPTION = "Running build target on Makefile"
     PURPOSE = Purpose.COMPILE_SOURCE
 
-    def __init__(self, artifacts_dir, scratch_dir, manifest_path, osutils, subprocess_make, build_logical_id):
+    def __init__(
+        self,
+        artifacts_dir,
+        scratch_dir,
+        manifest_path,
+        osutils,
+        subprocess_make,
+        build_logical_id,
+        working_directory=None,
+    ):
         """
         :type artifacts_dir: str
         :param artifacts_dir: directory where artifacts needs to be stored.
@@ -38,6 +47,12 @@ class CustomMakeAction(BaseAction):
 
         :type subprocess_make aws_lambda_builders.workflows.custom_make.make.SubprocessMake
         :param subprocess_make: An instance of the Make process wrapper
+
+        :type build_logical_id: str
+        :param build_logical_id: the lambda resource logical id that will be built by the custom action.
+
+        :type working_directory: str
+        :param working_directory: path to the working directory where the Makefile will be executed.
         """
         super(CustomMakeAction, self).__init__()
         self.artifacts_dir = artifacts_dir
@@ -46,6 +61,7 @@ class CustomMakeAction(BaseAction):
         self.osutils = osutils
         self.subprocess_make = subprocess_make
         self.build_logical_id = build_logical_id
+        self.working_directory = working_directory if working_directory else scratch_dir
 
     @property
     def artifact_dir_path(self):
@@ -91,7 +107,7 @@ class CustomMakeAction(BaseAction):
                     "build-{logical_id}".format(logical_id=self.build_logical_id),
                 ],
                 env=current_env,
-                cwd=self.scratch_dir,
+                cwd=self.working_directory,
             )
         except MakeExecutionError as ex:
             raise ActionFailedError(str(ex))

--- a/aws_lambda_builders/workflows/custom_make/utils.py
+++ b/aws_lambda_builders/workflows/custom_make/utils.py
@@ -35,15 +35,6 @@ class OSUtils(object):
     def abspath(self, path):
         return os.path.abspath(path)
 
-    def isabspath(self, path):
-        return os.path.isabs(path)
-
-    def relpath(self, path, start):
-        return os.path.relpath(path, start)
-
-    def join_relpath(self, path, start):
-        return os.path.join(start, path)
-
     @property
     def pipe(self):
         return subprocess.PIPE

--- a/aws_lambda_builders/workflows/custom_make/utils.py
+++ b/aws_lambda_builders/workflows/custom_make/utils.py
@@ -35,6 +35,15 @@ class OSUtils(object):
     def abspath(self, path):
         return os.path.abspath(path)
 
+    def isabspath(self, path):
+        return os.path.isabs(path)
+
+    def relpath(self, path, start):
+        return os.path.relpath(path, start)
+
+    def join_relpath(self, path, start):
+        return os.path.join(start, path)
+
     @property
     def pipe(self):
         return subprocess.PIPE

--- a/aws_lambda_builders/workflows/custom_make/workflow.py
+++ b/aws_lambda_builders/workflows/custom_make/workflow.py
@@ -34,21 +34,7 @@ class CustomMakeWorkflow(BaseWorkflow):
         # Find the logical id of the function to be built.
         options = kwargs.get("options") or {}
         build_logical_id = options.get("build_logical_id", None)
-        working_directory = options.get("working_directory")
-
-        if working_directory is None:
-            working_directory = scratch_dir
-        else:
-            if self.os_utils.isabspath(working_directory):
-                # Working directory should be relative to the source_dir, so when we copy the source_dir to scratch_dir
-                # the working directory value is still valid
-                working_directory = self.os_utils.relpath(working_directory, source_dir)
-
-            # join the working directory to the scratch_dir
-            working_directory = self.os_utils.normpath(self.os_utils.join_relpath(working_directory, scratch_dir))
-
-        if working_directory is None:
-            working_directory = scratch_dir
+        working_directory = options.get("working_directory", scratch_dir)
 
         if not build_logical_id:
             raise WorkflowFailedError(

--- a/aws_lambda_builders/workflows/custom_make/workflow.py
+++ b/aws_lambda_builders/workflows/custom_make/workflow.py
@@ -34,6 +34,21 @@ class CustomMakeWorkflow(BaseWorkflow):
         # Find the logical id of the function to be built.
         options = kwargs.get("options") or {}
         build_logical_id = options.get("build_logical_id", None)
+        working_directory = options.get("working_directory")
+
+        if working_directory is None:
+            working_directory = scratch_dir
+        else:
+            if self.os_utils.isabspath(working_directory):
+                # Working directory should be relative to the source_dir, so when we copy the source_dir to scratch_dir
+                # the working directory value is still valid
+                working_directory = self.os_utils.relpath(working_directory, source_dir)
+
+            # join the working directory to the scratch_dir
+            working_directory = self.os_utils.normpath(self.os_utils.join_relpath(working_directory, scratch_dir))
+
+        if working_directory is None:
+            working_directory = scratch_dir
 
         if not build_logical_id:
             raise WorkflowFailedError(
@@ -51,6 +66,7 @@ class CustomMakeWorkflow(BaseWorkflow):
             osutils=self.os_utils,
             subprocess_make=subprocess_make,
             build_logical_id=build_logical_id,
+            working_directory=working_directory,
         )
 
         self.actions = [CopySourceAction(source_dir, scratch_dir, excludes=self.EXCLUDED_FILES), make_action]

--- a/tests/integration/workflows/custom_make/test_custom_make.py
+++ b/tests/integration/workflows/custom_make/test_custom_make.py
@@ -99,35 +99,6 @@ class TestCustomMakeWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    def test_must_build_python_project_through_makefile_with_custom_relative_working_directory(self):
-        source_code = os.path.join(os.path.dirname(__file__), "testdata", "makefile-in-different-working-directory")
-        manifest_path_valid = os.path.join(source_code, "Makefile")
-        working_directory = "./source_code"
-        self.builder.build(
-            source_code,
-            self.artifacts_dir,
-            self.scratch_dir,
-            manifest_path_valid,
-            runtime=self.runtime,
-            options={"build_logical_id": "HelloWorldFunction", "working_directory": working_directory},
-        )
-        dependencies_installed = {
-            "chardet",
-            "urllib3",
-            "idna",
-            "urllib3-1.25.11.dist-info",
-            "chardet-3.0.4.dist-info",
-            "certifi-2020.4.5.2.dist-info",
-            "certifi",
-            "idna-2.10.dist-info",
-            "requests",
-            "requests-2.23.0.dist-info",
-        }
-
-        expected_files = self.test_data_files.union(dependencies_installed)
-        output_files = set(os.listdir(self.artifacts_dir))
-        self.assertEqual(expected_files, output_files)
-
     def test_must_build_python_project_through_makefile_unknown_target(self):
         with self.assertRaises(WorkflowFailedError):
             self.builder.build(

--- a/tests/integration/workflows/custom_make/test_custom_make.py
+++ b/tests/integration/workflows/custom_make/test_custom_make.py
@@ -57,6 +57,77 @@ class TestCustomMakeWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
+    def test_build_python_project_failed_through_makefile_without_working_directory(self):
+        source_code = os.path.join(os.path.dirname(__file__), "testdata", "makefile-in-different-working-directory")
+        manifest_path_valid = os.path.join(source_code, "Makefile")
+        with self.assertRaises(WorkflowFailedError):
+            self.builder.build(
+                source_code,
+                self.artifacts_dir,
+                self.scratch_dir,
+                manifest_path_valid,
+                runtime=self.runtime,
+                options={"build_logical_id": "HelloWorldFunction"},
+            )
+
+    def test_must_build_python_project_through_makefile_with_custom_working_directory(self):
+        source_code = os.path.join(os.path.dirname(__file__), "testdata", "makefile-in-different-working-directory")
+        manifest_path_valid = os.path.join(source_code, "Makefile")
+        working_directory = os.path.join(source_code, "source_code")
+        self.builder.build(
+            source_code,
+            self.artifacts_dir,
+            self.scratch_dir,
+            manifest_path_valid,
+            runtime=self.runtime,
+            options={"build_logical_id": "HelloWorldFunction", "working_directory": working_directory},
+        )
+        dependencies_installed = {
+            "chardet",
+            "urllib3",
+            "idna",
+            "urllib3-1.25.11.dist-info",
+            "chardet-3.0.4.dist-info",
+            "certifi-2020.4.5.2.dist-info",
+            "certifi",
+            "idna-2.10.dist-info",
+            "requests",
+            "requests-2.23.0.dist-info",
+        }
+
+        expected_files = self.test_data_files.union(dependencies_installed)
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)
+
+    def test_must_build_python_project_through_makefile_with_custom_relative_working_directory(self):
+        source_code = os.path.join(os.path.dirname(__file__), "testdata", "makefile-in-different-working-directory")
+        manifest_path_valid = os.path.join(source_code, "Makefile")
+        working_directory = "./source_code"
+        self.builder.build(
+            source_code,
+            self.artifacts_dir,
+            self.scratch_dir,
+            manifest_path_valid,
+            runtime=self.runtime,
+            options={"build_logical_id": "HelloWorldFunction", "working_directory": working_directory},
+        )
+        dependencies_installed = {
+            "chardet",
+            "urllib3",
+            "idna",
+            "urllib3-1.25.11.dist-info",
+            "chardet-3.0.4.dist-info",
+            "certifi-2020.4.5.2.dist-info",
+            "certifi",
+            "idna-2.10.dist-info",
+            "requests",
+            "requests-2.23.0.dist-info",
+        }
+
+        expected_files = self.test_data_files.union(dependencies_installed)
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)
+
     def test_must_build_python_project_through_makefile_unknown_target(self):
         with self.assertRaises(WorkflowFailedError):
             self.builder.build(

--- a/tests/integration/workflows/custom_make/test_custom_make.py
+++ b/tests/integration/workflows/custom_make/test_custom_make.py
@@ -57,7 +57,7 @@ class TestCustomMakeWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    def test_build_python_project_failed_through_makefile_without_working_directory(self):
+    def test_build_python_project_failed_through_makefile_no_python_source_in_default_working_directory(self):
         source_code = os.path.join(os.path.dirname(__file__), "testdata", "makefile-in-different-working-directory")
         manifest_path_valid = os.path.join(source_code, "Makefile")
         with self.assertRaises(WorkflowFailedError):

--- a/tests/integration/workflows/custom_make/testdata/makefile-in-different-working-directory/Makefile
+++ b/tests/integration/workflows/custom_make/testdata/makefile-in-different-working-directory/Makefile
@@ -1,0 +1,5 @@
+build-HelloWorldFunction:
+	cp *.py $(ARTIFACTS_DIR)
+	cp requirements-requests.txt $(ARTIFACTS_DIR)
+	python -m pip install -r requirements-requests.txt -t $(ARTIFACTS_DIR)
+	rm -rf $(ARTIFACTS_DIR)/bin

--- a/tests/integration/workflows/custom_make/testdata/makefile-in-different-working-directory/source_code/main.py
+++ b/tests/integration/workflows/custom_make/testdata/makefile-in-different-working-directory/source_code/main.py
@@ -1,0 +1,6 @@
+import requests
+
+
+def lambda_handler(event, context):
+    # Just return the requests version.
+    return "{}".format(requests.__version__)

--- a/tests/integration/workflows/custom_make/testdata/makefile-in-different-working-directory/source_code/requirements-requests.txt
+++ b/tests/integration/workflows/custom_make/testdata/makefile-in-different-working-directory/source_code/requirements-requests.txt
@@ -1,0 +1,4 @@
+requests==2.23.0
+
+# Pinning so the test can expect a given version
+certifi==2020.4.5.2 # dep of requests

--- a/tests/unit/workflows/custom_make/test_actions.py
+++ b/tests/unit/workflows/custom_make/test_actions.py
@@ -45,6 +45,32 @@ class TestProvidedMakeAction(TestCase):
 
     @patch("aws_lambda_builders.workflows.custom_make.utils.OSUtils")
     @patch("aws_lambda_builders.workflows.custom_make.make.SubProcessMake")
+    def test_call_makefile_target_with_working_directory(self, OSUtilMock, SubprocessMakeMock):
+        osutils = OSUtilMock.return_value
+        subprocess_make = SubprocessMakeMock.return_value
+
+        action = CustomMakeAction(
+            "artifacts",
+            "scratch_dir",
+            "manifest",
+            osutils=osutils,
+            subprocess_make=subprocess_make,
+            build_logical_id="logical_id",
+            working_directory="working_dir",
+        )
+
+        osutils.dirname.side_effect = lambda value: "/dir:{}".format(value)
+        osutils.abspath.side_effect = lambda value: "/abs:{}".format(value)
+        osutils.joinpath.side_effect = lambda a, b: "{}/{}".format(a, b)
+
+        action.execute()
+
+        subprocess_make.run.assert_called_with(
+            ["--makefile", "manifest", "build-logical_id"], cwd="working_dir", env=ANY
+        )
+
+    @patch("aws_lambda_builders.workflows.custom_make.utils.OSUtils")
+    @patch("aws_lambda_builders.workflows.custom_make.make.SubProcessMake")
     def test_makefile_target_fails(self, OSUtilMock, SubprocessMakeMock):
         osutils = OSUtilMock.return_value
         subprocess_make = SubprocessMakeMock.return_value

--- a/tests/unit/workflows/custom_make/test_workflow.py
+++ b/tests/unit/workflows/custom_make/test_workflow.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from aws_lambda_builders.architecture import X86_64, ARM64
 from aws_lambda_builders.actions import CopySourceAction
@@ -46,3 +47,42 @@ class TestProvidedMakeWorkflow(TestCase):
 
         self.assertEqual(workflow.architecture, "x86_64")
         self.assertEqual(workflow_with_arm.architecture, "arm64")
+
+    def test_use_scratch_dir_as_working_directory(self):
+        workflow = CustomMakeWorkflow(
+            "source", "artifacts", "scratch_dir", "manifest", options={"build_logical_id": "hello"}
+        )
+        self.assertEqual(workflow.actions[1].working_directory, "scratch_dir")
+
+    @patch("aws_lambda_builders.workflows.custom_make.workflow.OSUtils")
+    def test_use_relative_path_working_directory(self, OSUtilMock):
+        OSUtilMock.return_value.isabspath.return_value = False
+        OSUtilMock.return_value.join_relpath.return_value = "scratch_dir/working/dir/path"
+        OSUtilMock.return_value.normpath.return_value = "scratch_dir/working/dir/path"
+
+        workflow = CustomMakeWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "manifest",
+            options={"build_logical_id": "hello", "working_directory": "working/dir/path"},
+        )
+
+        self.assertEqual(workflow.actions[1].working_directory, "scratch_dir/working/dir/path")
+
+    @patch("aws_lambda_builders.workflows.custom_make.workflow.OSUtils")
+    def test_use_abs_path_working_directory(self, OSUtilMock):
+        OSUtilMock.return_value.isabspath.return_value = True
+        OSUtilMock.return_value.relpath.return_value = "working/dir/path"
+        OSUtilMock.return_value.join_relpath.return_value = "scratch_dir/working/dir/path"
+        OSUtilMock.return_value.normpath.return_value = "scratch_dir/working/dir/path"
+
+        workflow = CustomMakeWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "manifest",
+            options={"build_logical_id": "hello", "working_directory": "/source/working/dir/path"},
+        )
+
+        self.assertEqual(workflow.actions[1].working_directory, "scratch_dir/working/dir/path")

--- a/tests/unit/workflows/custom_make/test_workflow.py
+++ b/tests/unit/workflows/custom_make/test_workflow.py
@@ -54,12 +54,7 @@ class TestProvidedMakeWorkflow(TestCase):
         )
         self.assertEqual(workflow.actions[1].working_directory, "scratch_dir")
 
-    @patch("aws_lambda_builders.workflows.custom_make.workflow.OSUtils")
-    def test_use_relative_path_working_directory(self, OSUtilMock):
-        OSUtilMock.return_value.isabspath.return_value = False
-        OSUtilMock.return_value.join_relpath.return_value = "scratch_dir/working/dir/path"
-        OSUtilMock.return_value.normpath.return_value = "scratch_dir/working/dir/path"
-
+    def test_use_working_directory(self):
         workflow = CustomMakeWorkflow(
             "source",
             "artifacts",
@@ -68,21 +63,4 @@ class TestProvidedMakeWorkflow(TestCase):
             options={"build_logical_id": "hello", "working_directory": "working/dir/path"},
         )
 
-        self.assertEqual(workflow.actions[1].working_directory, "scratch_dir/working/dir/path")
-
-    @patch("aws_lambda_builders.workflows.custom_make.workflow.OSUtils")
-    def test_use_abs_path_working_directory(self, OSUtilMock):
-        OSUtilMock.return_value.isabspath.return_value = True
-        OSUtilMock.return_value.relpath.return_value = "working/dir/path"
-        OSUtilMock.return_value.join_relpath.return_value = "scratch_dir/working/dir/path"
-        OSUtilMock.return_value.normpath.return_value = "scratch_dir/working/dir/path"
-
-        workflow = CustomMakeWorkflow(
-            "source",
-            "artifacts",
-            "scratch_dir",
-            "manifest",
-            options={"build_logical_id": "hello", "working_directory": "/source/working/dir/path"},
-        )
-
-        self.assertEqual(workflow.actions[1].working_directory, "scratch_dir/working/dir/path")
+        self.assertEqual(workflow.actions[1].working_directory, "working/dir/path")


### PR DESCRIPTION
*Description of changes:*
Update the Custom builder workflow to accept a working directory within the options directory, to allow the custom builder to execute Makefile that exist outside the Lambda resources source code, or that run some building logic on a project level instead of lambda resource code path level.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
