### PR TITLE
chore: bump version to 1.19.0

### DIFF
--- a/aws_lambda_builders/__init__.py
+++ b/aws_lambda_builders/__init__.py
@@ -1,5 +1,5 @@
 """
 AWS Lambda Builder Library
 """
-__version__ = "1.18.0"
+__version__ = "1.19.0"
 RPC_PROTOCOL_VERSION = "0.3"


### PR DESCRIPTION
Bump aws-lambda-builders version to 1.19.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
