### PR TITLE
Support go1.x builder with the provided.al2 runtime

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,6 +90,7 @@ for:
       - sh: "nvm install ${nodejs_version}"
       - sh: "npm install npm@7.24.2 -g"
       - sh: "npm -v"
+      - sh: "go version"
       - sh: "echo $PATH"
       - sh: "java --version"
 

--- a/aws_lambda_builders/workflows/go_modules/validator.py
+++ b/aws_lambda_builders/workflows/go_modules/validator.py
@@ -52,15 +52,16 @@ class GoRuntimeValidator(RuntimeValidator):
 
         runtime_path = super(GoRuntimeValidator, self).validate(runtime_path)
 
-        expected_major_version = int(self.runtime.replace(self.LANGUAGE, "").split(".")[0])
-        min_expected_minor_version = 11 if expected_major_version == 1 else 0
+
 
         p = subprocess.Popen([runtime_path, "version"], cwd=os.getcwd(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         version_string, _ = p.communicate()
 
         if p.returncode == 0:
             major_version, minor_version = GoRuntimeValidator.get_go_versions(version_string.decode())
-            if major_version == expected_major_version and minor_version >= min_expected_minor_version:
+            min_expected_major_version = 1
+            min_expected_minor_version = 11 if major_version == 1 else 0
+            if major_version >= min_expected_major_version and minor_version >= min_expected_minor_version:
                 self._valid_runtime_path = runtime_path
                 return self._valid_runtime_path
 

--- a/aws_lambda_builders/workflows/go_modules/validator.py
+++ b/aws_lambda_builders/workflows/go_modules/validator.py
@@ -52,8 +52,6 @@ class GoRuntimeValidator(RuntimeValidator):
 
         runtime_path = super(GoRuntimeValidator, self).validate(runtime_path)
 
-
-
         p = subprocess.Popen([runtime_path, "version"], cwd=os.getcwd(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         version_string, _ = p.communicate()
 

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -35,4 +35,4 @@ class GoModulesWorkflow(BaseWorkflow):
         self.actions = [GoModulesBuildAction(source_dir, output_path, builder)]
 
     def get_validators(self):
-        return [GoRuntimeValidator(runtime="go1.x", architecture=self.architecture)]
+        return [GoRuntimeValidator(runtime=self.runtime, architecture=self.architecture)]

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -35,4 +35,4 @@ class GoModulesWorkflow(BaseWorkflow):
         self.actions = [GoModulesBuildAction(source_dir, output_path, builder)]
 
     def get_validators(self):
-        return [GoRuntimeValidator(runtime=self.runtime, architecture=self.architecture)]
+        return [GoRuntimeValidator(runtime="go1.x", architecture=self.architecture)]


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

I ran into this when trying to deploy a go function with the `arm64` platform. `go1.x` is `x86_64` only, so this requires the `provided.al2` runtime. The docs for the go runtime demonstrate [using the `Makefile` builder](https://docs.aws.amazon.com/lambda/latest/dg/golang-package.html#golang-package-al2) for using `provided.al2`. This works, but requires an extra project file compared to `go1.x`. I also saw in the docs that `BuildMethod` can be set the the value of a runtime, so tried that!

from: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html
> If a resource includes a Metadata resource attribute with a BuildMethod entry, sam build builds that resource according to the value of the BuildMethod entry. Valid values for BuildMethod are 1) One of the identifiers for a Lambda runtime, or 2) The makefile identifier.

Here's my test template.yaml:
```
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31
Resources:
  Hello:
    Type: AWS::Serverless::Function 
    Metadata:
      BuildMethod: go1.x
    Properties:
      CodeUri: .
      Handler: bootstrap
      Runtime: provided.al2
      Architectures:
      - arm64
      FunctionUrlConfig:
        AuthType: NONE
Outputs:
  HelloEndpoint:
    Description: "The Function URL!"
    Value:
      Fn::GetAtt: HelloUrl.FunctionUrl
```

And the error `sam build` throws:
```
$ sam build
Building codeuri: /Users/moffattb/sam-app runtime: provided.al2 metadata: {'BuildMethod': 'go1.x'} architecture: arm64 functions: Hello
Traceback (most recent call last):
  File "/usr/local/bin/sam", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/telemetry/metric.py", line 183, in wrapped
    raise exception  # pylint: disable=raising-bad-type
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/telemetry/metric.py", line 129, in wrapped
    return_value = func(*args, **kwargs)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/utils/version_checker.py", line 41, in wrapped
    actual_result = func(*args, **kwargs)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/cli/main.py", line 87, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/commands/build/command.py", line 182, in cli
    do_cli(
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/commands/build/command.py", line 262, in do_cli
    ctx.run()
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/commands/build/build_context.py", line 252, in run
    build_result = builder.build()
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/build/app_builder.py", line 221, in build
    return ApplicationBuildResult(build_graph, build_strategy.build())
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/build/build_strategy.py", line 80, in build
    result.update(self._build_functions(self._build_graph))
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/build/build_strategy.py", line 90, in _build_functions
    function_build_results.update(self.build_single_function_definition(build_definition))
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/build/build_strategy.py", line 163, in build_single_function_definition
    result = self._build_function(
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/build/app_builder.py", line 657, in _build_function
    return self._build_function_in_process(
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/samcli/lib/build/app_builder.py", line 746, in _build_function_in_process
    builder.build(
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/aws_lambda_builders/builder.py", line 164, in build
    return workflow.run()
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/aws_lambda_builders/workflow.py", line 65, in wrapper
    valid_path = binary_checker.validator.validate(executable_path)
  File "/usr/local/Cellar/aws-sam-cli/1.56.1/libexec/lib/python3.8/site-packages/aws_lambda_builders/workflows/go_modules/validator.py", line 55, in validate
    expected_major_version = int(self.runtime.replace(self.LANGUAGE, "").split(".")[0])
ValueError: invalid literal for int() with base 10: 'provided'
```

From a quick read, the runtime validator for the go modules builder seems to conflate the runtime enumeration value with the lookup path for the go compiler. This of course barfs if the runtime is anything other than `go*`. 

I manually tested this fix by following [CONTRIBUTING.md](https://github.com/aws/aws-lambda-builders/blob/4c12b411aefc0aea86bb87dea5ea8c3a34143f8f/CONTRIBUTING.md#testing-with-sam-cli) to setup `samdev`. 

```
(samcli) ~/sam-app
$ samdev build && samdev deploy
Building codeuri: /Users/moffattb/sam-app runtime: provided.al2 metadata: {'BuildMethod': 'go1.x'} architecture: arm64 functions: Hello
Running GoModulesBuilder:Build

Build Succeeded
...
Initiating deployment
=====================
...
Successfully created/updated stack - sam-app-hello in us-west-2
...
(samcli) ~/sam-app
$ curl https://<redacted>.lambda-url.us-west-2.on.aws/
Hello World!%
```

Happy to follow any guidance for updating this project's testing for additional coverage, I didn't get a chance to dig deeper into what's already present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.