### PR TITLE
Add `-trimpath` to GoModulesBuilder

### DIFF
--- a/aws_lambda_builders/workflows/go_modules/builder.py
+++ b/aws_lambda_builders/workflows/go_modules/builder.py
@@ -21,7 +21,7 @@ class GoModulesBuilder(object):
 
     LANGUAGE = "go"
 
-    def __init__(self, osutils, binaries, mode=BuildMode.RELEASE, architecture=X86_64):
+    def __init__(self, osutils, binaries, mode=BuildMode.RELEASE, architecture=X86_64, trim_go_path=False):
         """Initialize a GoModulesBuilder.
 
         :type osutils: :class:`lambda_builders.utils.OSUtils`
@@ -38,6 +38,7 @@ class GoModulesBuilder(object):
         self.binaries = binaries
         self.mode = mode
         self.goarch = get_goarch(architecture)
+        self.trim_go_path = trim_go_path
 
     def build(self, source_dir_path, output_path):
         """Builds a go project onto an output path.
@@ -53,6 +54,9 @@ class GoModulesBuilder(object):
         env.update({"GOOS": "linux", "GOARCH": self.goarch})
         runtime_path = self.binaries[self.LANGUAGE].binary_path
         cmd = [runtime_path, "build"]
+        if self.trim_go_path:
+            LOG.debug("Trimpath requested: Setting go build configuration to -trimpath")
+            cmd += ["-trimpath"]
         if self.mode and self.mode.lower() == BuildMode.DEBUG:
             LOG.debug("Debug build requested: Setting configuration to Debug")
             cmd += ["-gcflags", "all=-N -l"]

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -28,10 +28,11 @@ class GoModulesWorkflow(BaseWorkflow):
 
         options = kwargs.get("options") or {}
         handler = options.get("artifact_executable_name", None)
+        trim_go_path = options.get("trim_go_path", False)
 
         output_path = osutils.joinpath(artifacts_dir, handler)
 
-        builder = GoModulesBuilder(osutils, binaries=self.binaries, mode=mode, architecture=self.architecture)
+        builder = GoModulesBuilder(osutils, binaries=self.binaries, mode=mode, architecture=self.architecture, trim_go_path=trim_go_path)
         self.actions = [GoModulesBuildAction(source_dir, output_path, builder)]
 
     def get_validators(self):

--- a/tests/integration/workflows/go_modules/test_go.py
+++ b/tests/integration/workflows/go_modules/test_go.py
@@ -112,6 +112,19 @@ class TestGoWorkflow(TestCase):
             options={"artifact_executable_name": "no-deps-main-arm64"},
             architecture="arm64",
         )
-
         pathname = Path(self.artifacts_dir, "no-deps-main-arm64")
         self.assertEqual(get_executable_arch(pathname), "AArch64")
+
+    def test_builds_with_trimpath(self):
+        source_dir = os.path.join(self.TEST_DATA_FOLDER, "no-deps")
+        built_trimpath = self.builder.build(
+            source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            os.path.join(source_dir, "go.mod"),
+            runtime=self.runtime,
+            options={"artifact_executable_name": "no-deps-main-trimpath", "trim_go_path": True},
+            architecture="x86_64",
+        )
+        pathname = Path(self.artifacts_dir, "no-deps-main-trimpath")
+        self.assertEqual(get_executable_arch(pathname), "x64")

--- a/tests/unit/workflows/go_modules/test_builder.py
+++ b/tests/unit/workflows/go_modules/test_builder.py
@@ -61,6 +61,17 @@ class TestGoBuilder(TestCase):
             stdout="PIPE",
         )
 
+    def test_trimpath_configuration_set(self):
+        self.under_test = GoModulesBuilder(self.osutils, self.binaries, "release", "x86_64", True)
+        self.under_test.build("source_dir", "output_path")
+        self.osutils.popen.assert_called_with(
+            ["/path/to/go", "build", "-trimpath", "-o", "output_path", "source_dir"],
+            cwd="source_dir",
+            env={"GOOS": "linux", "GOARCH": "amd64"},
+            stderr="PIPE",
+            stdout="PIPE",
+        )
+
     def test_debug_configuration_set_with_arm_architecture(self):
         self.under_test = GoModulesBuilder(self.osutils, self.binaries, "Debug", "arm64")
         self.under_test.build("source_dir", "output_path")


### PR DESCRIPTION
This PR addresses the issue described [here](https://github.com/aws/aws-sam-cli/issues/3258) in the AWS SAM CLI [repository](https://github.com/aws/aws-sam-cli). 

*Description of changes:*
Adds a `trim_go_path` option to the `GoModulesBuilder`. Directly from the `go help build` command from the Go CLI: 
```
-trimpath
                remove all file system paths from the resulting executable.
		Instead of absolute file system paths, the recorded file names
		will begin either a module path@version (when using modules),
		or a plain import path (when using the standard library, or GOPATH).
```

Ultimately, this addresses an issue that occurs when using `sam build`. Without `-trimpath` the compiled binaries computed hashes are different each time forcing CloudFormation to redeploy a Lambda function without code changes. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
