### PR TITLE
chore: Version bump from 1.23.0 to 1.23.1

### DIFF
--- a/aws_lambda_builders/__init__.py
+++ b/aws_lambda_builders/__init__.py
@@ -4,5 +4,5 @@ AWS Lambda Builder Library
 
 # Changing version will trigger a new release!
 # Please make the version change as the last step of your development.
-__version__ = "1.23.0"
+__version__ = "1.23.1"
 RPC_PROTOCOL_VERSION = "0.3"


### PR DESCRIPTION
*Description of changes:*
Bumping the Lambda Builders version from `1.23.0` to `1.23.1`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
