### PR TITLE
fix: Copy over shrinkwrap if it exists

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -165,7 +165,7 @@ class NodejsNpmrcAndLockfileCopyAction(BaseAction):
     """
 
     NAME = "CopyNpmrcAndLockfile"
-    DESCRIPTION = "Copying configuration from .npmrc and dependencies from lockfile"
+    DESCRIPTION = "Copying configuration from .npmrc and dependencies from lockfile/shrinkwrap"
     PURPOSE = Purpose.COPY_SOURCE
 
     def __init__(self, artifacts_dir, source_dir, osutils):
@@ -194,7 +194,7 @@ class NodejsNpmrcAndLockfileCopyAction(BaseAction):
         """
 
         try:
-            for filename in [".npmrc", "package-lock.json"]:
+            for filename in [".npmrc", "package-lock.json", "npm-shrinkwrap.json"]:
                 file_path = self.osutils.joinpath(self.source_dir, filename)
                 if self.osutils.file_exists(file_path):
                     LOG.debug("%s copying in: %s", filename, self.artifacts_dir)

--- a/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
+++ b/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -32,7 +33,8 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         npm = SubprocessNpm(self.osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
         npm.run(["ci"], cwd=esbuild_dir)
-        self.binpath = npm.run(["bin"], cwd=esbuild_dir)
+        self.root_path = npm.run(["root"], cwd=esbuild_dir)
+        self.binpath = Path(self.root_path, ".bin")
 
     def tearDown(self):
         shutil.rmtree(self.artifacts_dir)
@@ -168,7 +170,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         npm = SubprocessNpm(osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
         npm.run(["ci"], cwd=esbuild_dir)
-        binpath = npm.run(["bin"], cwd=esbuild_dir)
+        binpath = Path(npm.run(["root"], cwd=esbuild_dir), ".bin")
 
         self.builder.build(
             source_dir,
@@ -194,7 +196,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         npm = SubprocessNpm(osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
         npm.run(["ci"], cwd=esbuild_dir)
-        binpath = npm.run(["bin"], cwd=esbuild_dir)
+        binpath = Path(npm.run(["root"], cwd=esbuild_dir), ".bin")
 
         self.builder.build(
             source_dir,

--- a/tests/unit/workflows/nodejs_npm/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm/test_actions.py
@@ -113,24 +113,31 @@ class TestNodejsNpmCIAction(TestCase):
 class TestNodejsNpmrcAndLockfileCopyAction(TestCase):
     @parameterized.expand(
         [
-            [False, False],
-            [True, False],
-            [False, True],
-            [True, True],
+            [False, False, False],
+            [True, False, False],
+            [False, True, False],
+            [True, True, False],
+            [False, False, True],
+            [True, False, True],
+            [False, True, True],
+            [True, True, True],
         ]
     )
     @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
-    def test_copies_into_a_project_if_file_exists(self, npmrc_exists, package_lock_exists, OSUtilMock):
+    def test_copies_into_a_project_if_file_exists(
+        self, npmrc_exists, package_lock_exists, shrinkwrap_exists, OSUtilMock
+    ):
         osutils = OSUtilMock.return_value
         osutils.joinpath.side_effect = lambda a, b: "{}/{}".format(a, b)
 
         action = NodejsNpmrcAndLockfileCopyAction("artifacts", "source", osutils=osutils)
-        osutils.file_exists.side_effect = [npmrc_exists, package_lock_exists]
+        osutils.file_exists.side_effect = [npmrc_exists, package_lock_exists, shrinkwrap_exists]
         action.execute()
 
         filename_exists = {
             ".npmrc": npmrc_exists,
             "package-lock.json": package_lock_exists,
+            "npm-shrinkwrap.json": shrinkwrap_exists,
         }
         file_exists_calls = [call("source/{}".format(filename)) for filename in filename_exists]
         copy_file_calls = [

--- a/tests/unit/workflows/nodejs_npm/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm/test_actions.py
@@ -1,3 +1,4 @@
+import itertools
 from unittest import TestCase
 from mock import patch, call
 from parameterized import parameterized
@@ -112,16 +113,7 @@ class TestNodejsNpmCIAction(TestCase):
 
 class TestNodejsNpmrcAndLockfileCopyAction(TestCase):
     @parameterized.expand(
-        [
-            [False, False, False],
-            [True, False, False],
-            [False, True, False],
-            [True, True, False],
-            [False, False, True],
-            [True, False, True],
-            [False, True, True],
-            [True, True, True],
-        ]
+        itertools.product([True, False], [True, False], [True, False])
     )
     @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
     def test_copies_into_a_project_if_file_exists(

--- a/tests/unit/workflows/nodejs_npm/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm/test_actions.py
@@ -112,9 +112,7 @@ class TestNodejsNpmCIAction(TestCase):
 
 
 class TestNodejsNpmrcAndLockfileCopyAction(TestCase):
-    @parameterized.expand(
-        itertools.product([True, False], [True, False], [True, False])
-    )
+    @parameterized.expand(itertools.product([True, False], [True, False], [True, False]))
     @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
     def test_copies_into_a_project_if_file_exists(
         self, npmrc_exists, package_lock_exists, shrinkwrap_exists, OSUtilMock


### PR DESCRIPTION
*Description of changes:*
`npm 9.x` no longer packs the `npm-shrinkwrap.json` so we need to do it ourselves to respect this file during installation, similarly to how to copy over the `package-lock.json`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
