### PR TITLE
feat: handle default and supported values for building in source per workflow

### DIFF
--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -140,10 +140,13 @@ class _WorkflowMetaClass(type):
         if not isinstance(cls.CAPABILITY, Capability):
             raise ValueError("Workflow '{}' must register valid capabilities".format(cls.NAME))
 
-        # All workflows must define default value and supported values for build in source
-        if cls.BUILD_IN_SOURCE_BY_DEFAULT is None or cls.BUILD_IN_SOURCE_SUPPORT is None:
+        # All workflows must define valid default and supported values for build in source
+        if (
+            not isinstance(cls.BUILD_IN_SOURCE_SUPPORT, BuildInSourceSupport)
+            or cls.BUILD_IN_SOURCE_BY_DEFAULT not in cls.BUILD_IN_SOURCE_SUPPORT.value
+        ):
             raise ValueError(
-                "Workflow '{}' must define default value and supported values for build in source".format(cls.NAME)
+                "Workflow '{}' must define valid default and supported values for build in source".format(cls.NAME)
             )
 
         LOG.debug("Registering workflow '%s' with capability '%s'", cls.NAME, cls.CAPABILITY)

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -261,26 +261,18 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
         self.build_in_source = build_in_source
         if build_in_source is None:
             self.build_in_source = self.BUILD_IN_SOURCE_BY_DEFAULT
-        self._validate_build_in_source()
+        elif build_in_source not in self.BUILD_IN_SOURCE_SUPPORT.value:
+            LOG.warning(
+                'Workflow %s does not support value "%s" for building in source. Using default value: %s.',
+                self.NAME,
+                build_in_source,
+                self.BUILD_IN_SOURCE_BY_DEFAULT,
+            )
+            self.build_in_source = self.BUILD_IN_SOURCE_BY_DEFAULT
 
         # Actions are registered by the subclasses as they seem fit
         self.actions = []
         self._binaries = {}
-
-    def _validate_build_in_source(self):
-        """
-        Validates that the value of build_in_source is supported by the chosen workflow.
-        """
-        if self.build_in_source not in self.BUILD_IN_SOURCE_SUPPORT.value:
-            error_reason = ""
-            if self.BUILD_IN_SOURCE_SUPPORT == BuildInSourceSupport.NOT_SUPPORTED:
-                error_reason = "This workflow does not support building in source"
-            elif self.BUILD_IN_SOURCE_SUPPORT == BuildInSourceSupport.EXCLUSIVELY_SUPPORTED:
-                error_reason = "This workflow only supports building in source"
-            else:
-                error_reason = "Unsupported value for build_in_source"
-
-            raise WorkflowFailedError(workflow_name=self.NAME, action_name=None, reason=error_reason)
 
     def is_supported(self):
         """

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -266,7 +266,7 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
             self.build_in_source = self.BUILD_IN_SOURCE_BY_DEFAULT
         elif build_in_source not in self.BUILD_IN_SOURCE_SUPPORT.value:
             LOG.warning(
-                'Workflow %s does not support value "%s" for building in source. Using default value: %s.',
+                'Workflow %s does not support value "%s" for building in source. Using default value "%s".',
                 self.NAME,
                 build_in_source,
                 self.BUILD_IN_SOURCE_BY_DEFAULT,

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -262,15 +262,15 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
         self.experimental_flags = experimental_flags if experimental_flags else []
 
         self.build_in_source = build_in_source
-        if build_in_source is None:
-            self.build_in_source = self.BUILD_IN_SOURCE_BY_DEFAULT
-        elif build_in_source not in self.BUILD_IN_SOURCE_SUPPORT.value:
-            LOG.warning(
-                'Workflow %s does not support value "%s" for building in source. Using default value "%s".',
-                self.NAME,
-                build_in_source,
-                self.BUILD_IN_SOURCE_BY_DEFAULT,
-            )
+        if build_in_source not in self.BUILD_IN_SOURCE_SUPPORT.value:
+            # only show warning if an unsupported value was explicitly passed in
+            if build_in_source is not None:
+                LOG.warning(
+                    'Workflow %s does not support value "%s" for building in source. Using default value "%s".',
+                    self.NAME,
+                    build_in_source,
+                    self.BUILD_IN_SOURCE_BY_DEFAULT,
+                )
             self.build_in_source = self.BUILD_IN_SOURCE_BY_DEFAULT
 
         # Actions are registered by the subclasses as they seem fit

--- a/aws_lambda_builders/workflows/custom_make/workflow.py
+++ b/aws_lambda_builders/workflows/custom_make/workflow.py
@@ -2,7 +2,7 @@
 ProvidedMakeWorkflow
 """
 from aws_lambda_builders.workflows.custom_make.validator import CustomMakeRuntimeValidator
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
 from aws_lambda_builders.actions import CopySourceAction
 from aws_lambda_builders.path_resolver import PathResolver
 from .actions import CustomMakeAction
@@ -22,6 +22,9 @@ class CustomMakeWorkflow(BaseWorkflow):
     CAPABILITY = Capability(language="provided", dependency_manager=None, application_framework=None)
 
     EXCLUDED_FILES = (".aws-sam", ".git")
+
+    BUILD_IN_SOURCE_BY_DEFAULT = False
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):
 
@@ -43,10 +46,6 @@ class CustomMakeWorkflow(BaseWorkflow):
             )
 
         subprocess_make = SubProcessMake(make_exe=self.binaries["make"].binary_path, osutils=self.os_utils)
-
-        # Don't build in source by default (backwards compatibility)
-        if build_in_source is None:
-            build_in_source = False
 
         # an explicitly definied working directory should take precedence
         working_directory = options.get("working_directory") or self._select_working_directory(

--- a/aws_lambda_builders/workflows/dotnet_clipackage/workflow.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/workflow.py
@@ -1,7 +1,7 @@
 """
 .NET Core CLI Package Workflow
 """
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
 
 from .actions import GlobalToolInstallAction, RunPackageAction
 from .dotnetcli import SubprocessDotnetCLI
@@ -18,6 +18,9 @@ class DotnetCliPackageWorkflow(BaseWorkflow):
     NAME = "DotnetCliPackageBuilder"
 
     CAPABILITY = Capability(language="dotnet", dependency_manager="cli-package", application_framework=None)
+
+    BUILD_IN_SOURCE_BY_DEFAULT = True
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.EXCLUSIVELY_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, mode=None, **kwargs):
 

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -1,7 +1,7 @@
 """
 Go Modules Workflow
 """
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
 
 from .actions import GoModulesBuildAction
 from .builder import GoModulesBuilder
@@ -14,6 +14,9 @@ class GoModulesWorkflow(BaseWorkflow):
     NAME = "GoModulesBuilder"
 
     CAPABILITY = Capability(language="go", dependency_manager="modules", application_framework=None)
+
+    BUILD_IN_SOURCE_BY_DEFAULT = True
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.EXCLUSIVELY_SUPPORTED
 
     def __init__(
         self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, mode=None, **kwargs

--- a/aws_lambda_builders/workflows/java_gradle/workflow.py
+++ b/aws_lambda_builders/workflows/java_gradle/workflow.py
@@ -4,7 +4,7 @@ Java Gradle Workflow
 import hashlib
 import os
 from aws_lambda_builders.actions import CleanUpAction
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
 from aws_lambda_builders.workflows.java.actions import JavaCopyDependenciesAction, JavaMoveDependenciesAction
 from aws_lambda_builders.workflows.java.utils import OSUtils
 
@@ -24,6 +24,9 @@ class JavaGradleWorkflow(BaseWorkflow):
     CAPABILITY = Capability(language="java", dependency_manager="gradle", application_framework=None)
 
     INIT_FILE = "lambda-build-init.gradle"
+
+    BUILD_IN_SOURCE_BY_DEFAULT = False
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, **kwargs):
         super(JavaGradleWorkflow, self).__init__(source_dir, artifacts_dir, scratch_dir, manifest_path, **kwargs)

--- a/aws_lambda_builders/workflows/java_maven/workflow.py
+++ b/aws_lambda_builders/workflows/java_maven/workflow.py
@@ -1,7 +1,7 @@
 """
 Java Maven Workflow
 """
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
 from aws_lambda_builders.actions import CopySourceAction, CleanUpAction
 from aws_lambda_builders.workflows.java.actions import JavaCopyDependenciesAction, JavaMoveDependenciesAction
 from aws_lambda_builders.workflows.java.utils import OSUtils
@@ -27,6 +27,9 @@ class JavaMavenWorkflow(BaseWorkflow):
     CAPABILITY = Capability(language="java", dependency_manager="maven", application_framework=None)
 
     EXCLUDED_FILES = (".aws-sam", ".git")
+
+    BUILD_IN_SOURCE_BY_DEFAULT = False
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, **kwargs):
         super(JavaMavenWorkflow, self).__init__(source_dir, artifacts_dir, scratch_dir, manifest_path, **kwargs)

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -5,7 +5,7 @@ NodeJS NPM Workflow
 import logging
 
 from aws_lambda_builders.path_resolver import PathResolver
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
 from aws_lambda_builders.actions import (
     CopySourceAction,
     CleanUpAction,
@@ -41,6 +41,9 @@ class NodejsNpmWorkflow(BaseWorkflow):
     EXCLUDED_FILES = (".aws-sam", ".git")
 
     CONFIG_PROPERTY = "aws_sam"
+
+    BUILD_IN_SOURCE_BY_DEFAULT = False
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):
 

--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import List
 
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
 from aws_lambda_builders.actions import (
     CopySourceAction,
     CleanUpAction,
@@ -43,6 +43,9 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
     EXCLUDED_FILES = (".aws-sam", ".git")
 
     CONFIG_PROPERTY = "aws_sam"
+
+    BUILD_IN_SOURCE_BY_DEFAULT = False
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):
 

--- a/aws_lambda_builders/workflows/python_pip/workflow.py
+++ b/aws_lambda_builders/workflows/python_pip/workflow.py
@@ -3,7 +3,7 @@ Python PIP Workflow
 """
 import logging
 
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, BuildInSourceSupport, Capability
 from aws_lambda_builders.actions import CopySourceAction, CleanUpAction, LinkSourceAction
 from aws_lambda_builders.workflows.python_pip.validator import PythonRuntimeValidator
 from aws_lambda_builders.path_resolver import PathResolver
@@ -66,6 +66,9 @@ class PythonPipWorkflow(BaseWorkflow):
     )
 
     PYTHON_VERSION_THREE = "3"
+
+    BUILD_IN_SOURCE_BY_DEFAULT = False
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):
 

--- a/aws_lambda_builders/workflows/ruby_bundler/workflow.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/workflow.py
@@ -3,7 +3,7 @@ Ruby Bundler Workflow
 """
 import logging
 
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, BuildInSourceSupport, Capability
 from aws_lambda_builders.actions import CopySourceAction, CopyDependenciesAction, CleanUpAction
 from .actions import RubyBundlerInstallAction, RubyBundlerVendorAction
 from .utils import OSUtils
@@ -24,6 +24,9 @@ class RubyBundlerWorkflow(BaseWorkflow):
     CAPABILITY = Capability(language="ruby", dependency_manager="bundler", application_framework=None)
 
     EXCLUDED_FILES = (".aws-sam", ".git")
+
+    BUILD_IN_SOURCE_BY_DEFAULT = False
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):
 

--- a/tests/functional/testdata/workflows/hello_workflow/write_hello.py
+++ b/tests/functional/testdata/workflows/hello_workflow/write_hello.py
@@ -4,7 +4,7 @@ Provides a test workflow and action that writes a file to artifacts called hello
 
 import os
 
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, BuildInSourceSupport, Capability
 from aws_lambda_builders.actions import BaseAction, Purpose
 
 
@@ -34,6 +34,8 @@ class WriteHelloWorkflow(BaseWorkflow):
 
     NAME = "WriteHelloWorkflow"
     CAPABILITY = Capability(language="python", dependency_manager="test", application_framework="test")
+    BUILD_IN_SOURCE_BY_DEFAULT = False
+    BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, *args, **kwargs):
         super(WriteHelloWorkflow, self).__init__(source_dir, artifacts_dir, *args, **kwargs)

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -4,7 +4,7 @@ from mock import patch, call, Mock
 from parameterized import parameterized, param
 
 from aws_lambda_builders.builder import LambdaBuilder
-from aws_lambda_builders.workflow import Capability, BaseWorkflow
+from aws_lambda_builders.workflow import BuildInSourceSupport, Capability, BaseWorkflow
 from aws_lambda_builders.registry import DEFAULT_REGISTRY
 
 
@@ -71,6 +71,8 @@ class TesetLambdaBuilder_init(TestCase):
             CAPABILITY = Capability(
                 language=self.lang, dependency_manager=self.lang_framework, application_framework=self.app_framework
             )
+            BUILD_IN_SOURCE_BY_DEFAULT = False
+            BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
             def __init__(
                 self,

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -449,7 +449,9 @@ class TestBaseWorkflow_build_in_source(TestCase):
             ("unsupported", False, BuildInSourceSupport.OPTIONALLY_SUPPORTED),  # unsupported value passed in
         ]
     )
-    def test_must_validate_value(self, build_in_source_value, build_in_source_default, build_in_source_support):
+    def test_must_use_default_if_unsupported_value_is_provided(
+        self, build_in_source_value, build_in_source_default, build_in_source_support
+    ):
         class MyWorkflow(BaseWorkflow):
             __TESTING__ = True
             NAME = "MyWorkflow"
@@ -459,52 +461,16 @@ class TestBaseWorkflow_build_in_source(TestCase):
             BUILD_IN_SOURCE_BY_DEFAULT = build_in_source_default
             BUILD_IN_SOURCE_SUPPORT = build_in_source_support
 
-        with self.assertRaises(WorkflowFailedError):
-            self.work = MyWorkflow(
-                "source_dir",
-                "artifacts_dir",
-                "scratch_dir",
-                "manifest_path",
-                runtime="runtime",
-                executable_search_paths=[str(sys.executable)],
-                optimizations={"a": "b"},
-                options={"c": "d"},
-                build_in_source=build_in_source_value,
-            )
+        self.work = MyWorkflow(
+            "source_dir",
+            "artifacts_dir",
+            "scratch_dir",
+            "manifest_path",
+            runtime="runtime",
+            executable_search_paths=[str(sys.executable)],
+            optimizations={"a": "b"},
+            options={"c": "d"},
+            build_in_source=build_in_source_value,
+        )
 
-    @parameterized.expand(
-        [
-            (True, BuildInSourceSupport.NOT_SUPPORTED),
-            (False, BuildInSourceSupport.EXCLUSIVELY_SUPPORTED),
-        ]
-    )
-    def test_validate_default_value_is_supported(self, build_in_source_default, build_in_source_support):
-        class MyWorkflow(BaseWorkflow):
-            __TESTING__ = True
-            NAME = "MyWorkflow"
-            CAPABILITY = Capability(
-                language="test", dependency_manager="testframework", application_framework="appframework"
-            )
-            BUILD_IN_SOURCE_BY_DEFAULT = build_in_source_default
-            BUILD_IN_SOURCE_SUPPORT = build_in_source_support
-
-        with self.assertRaises(WorkflowFailedError):
-            self.work = MyWorkflow(
-                "source_dir",
-                "artifacts_dir",
-                "scratch_dir",
-                "manifest_path",
-                runtime="runtime",
-                executable_search_paths=[str(sys.executable)],
-                optimizations={"a": "b"},
-                options={"c": "d"},
-            )
-
-    def test_workflow_must_define_default_and_supported_values(self):
-        with self.assertRaises(ValueError):
-
-            class MyWorkflow(BaseWorkflow):
-                NAME = "MyWorkflow"
-                CAPABILITY = Capability(
-                    language="test", dependency_manager="testframework", application_framework="appframework"
-                )
+        self.assertEqual(self.work.build_in_source, build_in_source_default)

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from unittest import TestCase
+from parameterized import parameterized
 
 from mock import Mock, MagicMock, call
 
@@ -11,7 +12,7 @@ except ImportError:
 
 from aws_lambda_builders.binary_path import BinaryPath
 from aws_lambda_builders.validator import RuntimeValidator
-from aws_lambda_builders.workflow import BaseWorkflow, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, BuildInSourceSupport, Capability
 from aws_lambda_builders.registry import get_workflow, DEFAULT_REGISTRY
 from aws_lambda_builders.exceptions import (
     WorkflowFailedError,
@@ -40,6 +41,8 @@ class TestRegisteringWorkflows(TestCase):
         class TestWorkflow(BaseWorkflow):
             NAME = "TestWorkflow"
             CAPABILITY = self.CAPABILITY1
+            BUILD_IN_SOURCE_BY_DEFAULT = False
+            BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
         result_cls = get_workflow(self.CAPABILITY1)
         self.assertEqual(len(DEFAULT_REGISTRY), 1)
@@ -49,10 +52,14 @@ class TestRegisteringWorkflows(TestCase):
         class TestWorkflow1(BaseWorkflow):
             NAME = "TestWorkflow"
             CAPABILITY = self.CAPABILITY1
+            BUILD_IN_SOURCE_BY_DEFAULT = False
+            BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
         class TestWorkflow2(BaseWorkflow):
             NAME = "TestWorkflow2"
             CAPABILITY = self.CAPABILITY2
+            BUILD_IN_SOURCE_BY_DEFAULT = False
+            BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
         self.assertEqual(len(DEFAULT_REGISTRY), 2)
         self.assertEqual(get_workflow(self.CAPABILITY1), TestWorkflow1)
@@ -97,6 +104,8 @@ class TestBaseWorkflow_init(TestCase):
         CAPABILITY = Capability(
             language="test", dependency_manager="testframework", application_framework="appframework"
         )
+        BUILD_IN_SOURCE_BY_DEFAULT = False
+        BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
     def test_must_initialize_variables(self):
         self.work = self.MyWorkflow(
@@ -108,6 +117,7 @@ class TestBaseWorkflow_init(TestCase):
             executable_search_paths=[str(sys.executable)],
             optimizations={"a": "b"},
             options={"c": "d"},
+            build_in_source=True,
         )
 
         self.assertEqual(self.work.source_dir, "source_dir")
@@ -119,6 +129,7 @@ class TestBaseWorkflow_init(TestCase):
         self.assertEqual(self.work.optimizations, {"a": "b"})
         self.assertEqual(self.work.options, {"c": "d"})
         self.assertEqual(self.work.architecture, "x86_64")
+        self.assertTrue(self.work.build_in_source)
 
 
 class TestBaseWorkflow_is_supported(TestCase):
@@ -128,6 +139,8 @@ class TestBaseWorkflow_is_supported(TestCase):
         CAPABILITY = Capability(
             language="test", dependency_manager="testframework", application_framework="appframework"
         )
+        BUILD_IN_SOURCE_BY_DEFAULT = False
+        BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
     def setUp(self):
         self.work = self.MyWorkflow(
@@ -174,6 +187,8 @@ class TestBaseWorkflow_run(TestCase):
         CAPABILITY = Capability(
             language="test", dependency_manager="testframework", application_framework="appframework"
         )
+        BUILD_IN_SOURCE_BY_DEFAULT = False
+        BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
     def setUp(self):
         self.work = self.MyWorkflow(
@@ -359,6 +374,8 @@ class TestBaseWorkflow_repr(TestCase):
         CAPABILITY = Capability(
             language="test", dependency_manager="testframework", application_framework="appframework"
         )
+        BUILD_IN_SOURCE_BY_DEFAULT = False
+        BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
     def setUp(self):
         self.action1 = Mock()
@@ -394,3 +411,100 @@ Actions=
 \tName=Action3, Purpose=COMPILE_SOURCE, Description=Compiles code"""
 
         self.assertEqual(result, expected)
+
+
+class TestBaseWorkflow_build_in_source(TestCase):
+    @parameterized.expand([(True,), (False,)])
+    def test_must_use_correct_default_value(self, default_value):
+        class MyWorkflow(BaseWorkflow):
+            __TESTING__ = True
+            NAME = "MyWorkflow"
+            CAPABILITY = Capability(
+                language="test", dependency_manager="testframework", application_framework="appframework"
+            )
+            BUILD_IN_SOURCE_BY_DEFAULT = default_value
+            BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
+
+        self.work = MyWorkflow(
+            "source_dir",
+            "artifacts_dir",
+            "scratch_dir",
+            "manifest_path",
+            runtime="runtime",
+            executable_search_paths=[str(sys.executable)],
+            optimizations={"a": "b"},
+            options={"c": "d"},
+        )
+
+        self.assertEqual(self.work.build_in_source, default_value)
+
+    @parameterized.expand(
+        [
+            (True, False, BuildInSourceSupport.NOT_SUPPORTED),  # want to build in source but it's not supported
+            (
+                False,
+                True,
+                BuildInSourceSupport.EXCLUSIVELY_SUPPORTED,
+            ),  # don't want to build in source but workflow requires it
+            ("unsupported", False, BuildInSourceSupport.OPTIONALLY_SUPPORTED),  # unsupported value passed in
+        ]
+    )
+    def test_must_validate_value(self, build_in_source_value, build_in_source_default, build_in_source_support):
+        class MyWorkflow(BaseWorkflow):
+            __TESTING__ = True
+            NAME = "MyWorkflow"
+            CAPABILITY = Capability(
+                language="test", dependency_manager="testframework", application_framework="appframework"
+            )
+            BUILD_IN_SOURCE_BY_DEFAULT = build_in_source_default
+            BUILD_IN_SOURCE_SUPPORT = build_in_source_support
+
+        with self.assertRaises(WorkflowFailedError):
+            self.work = MyWorkflow(
+                "source_dir",
+                "artifacts_dir",
+                "scratch_dir",
+                "manifest_path",
+                runtime="runtime",
+                executable_search_paths=[str(sys.executable)],
+                optimizations={"a": "b"},
+                options={"c": "d"},
+                build_in_source=build_in_source_value,
+            )
+
+    @parameterized.expand(
+        [
+            (True, BuildInSourceSupport.NOT_SUPPORTED),
+            (False, BuildInSourceSupport.EXCLUSIVELY_SUPPORTED),
+        ]
+    )
+    def test_validate_default_value_is_supported(self, build_in_source_default, build_in_source_support):
+        class MyWorkflow(BaseWorkflow):
+            __TESTING__ = True
+            NAME = "MyWorkflow"
+            CAPABILITY = Capability(
+                language="test", dependency_manager="testframework", application_framework="appframework"
+            )
+            BUILD_IN_SOURCE_BY_DEFAULT = build_in_source_default
+            BUILD_IN_SOURCE_SUPPORT = build_in_source_support
+
+        with self.assertRaises(WorkflowFailedError):
+            self.work = MyWorkflow(
+                "source_dir",
+                "artifacts_dir",
+                "scratch_dir",
+                "manifest_path",
+                runtime="runtime",
+                executable_search_paths=[str(sys.executable)],
+                optimizations={"a": "b"},
+                options={"c": "d"},
+            )
+
+    def test_workflow_must_define_default_and_supported_values(self):
+        with self.assertRaises(ValueError):
+
+            class MyWorkflow(BaseWorkflow):
+                NAME = "MyWorkflow"
+                CAPABILITY = Capability(
+                    language="test", dependency_manager="testframework", application_framework="appframework"
+                )

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -71,6 +71,8 @@ class TestRegisteringWorkflows(TestCase):
 
             class TestWorkflow1(BaseWorkflow):
                 CAPABILITY = self.CAPABILITY1
+                BUILD_IN_SOURCE_BY_DEFAULT = False
+                BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
         self.assertEqual(len(DEFAULT_REGISTRY), 0)
         self.assertEqual(str(ctx.exception), "Workflow must provide a valid name")
@@ -81,6 +83,8 @@ class TestRegisteringWorkflows(TestCase):
 
             class TestWorkflow1(BaseWorkflow):
                 NAME = "somename"
+                BUILD_IN_SOURCE_BY_DEFAULT = False
+                BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
         self.assertEqual(len(DEFAULT_REGISTRY), 0)
         self.assertEqual(str(ctx.exception), "Workflow 'somename' must register valid capabilities")
@@ -92,9 +96,31 @@ class TestRegisteringWorkflows(TestCase):
             class TestWorkflow1(BaseWorkflow):
                 NAME = "somename"
                 CAPABILITY = "wrong data type"
+                BUILD_IN_SOURCE_BY_DEFAULT = False
+                BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
         self.assertEqual(len(DEFAULT_REGISTRY), 0)
         self.assertEqual(str(ctx.exception), "Workflow 'somename' must register valid capabilities")
+
+    @parameterized.expand(
+        [
+            (None, BuildInSourceSupport.NOT_SUPPORTED),  # default not defined
+            (False, None),  # support not defined
+            (False, BuildInSourceSupport.EXCLUSIVELY_SUPPORTED),  # default incompatible with support
+            (True, False),  # support not instance of enum
+        ]
+    )
+    def test_must_fail_if_build_in_source_variables_invalid(self, build_in_source_default, build_in_source_support):
+
+        with self.assertRaises(ValueError) as ctx:
+
+            class TestWorkflow1(BaseWorkflow):
+                NAME = "somename"
+                CAPABILITY = self.CAPABILITY1
+                BUILD_IN_SOURCE_BY_DEFAULT = build_in_source_default
+                BUILD_IN_SOURCE_SUPPORT = build_in_source_support
+
+        self.assertEqual(len(DEFAULT_REGISTRY), 0)
 
 
 class TestBaseWorkflow_init(TestCase):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Building in source
- handles default values for each workflow
- handles supported values for each workflow
- ensures each workflow should define its own defaults and supported values
- error handling if the passed-in value is not supported by the workflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
