### PR TITLE
chore: update badges and build support list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ## Lambda Builders
 
-[![Build & Test](https://github.com/aws/aws-lambda-builders/actions/workflows/build.yml/badge.svg)](https://github.com/aws/aws-lambda-builders/actions/workflows/build.yml)
+![Apache 2.0 License](https://img.shields.io/github/license/aws/aws-lambda-builders)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/aws/aws-lambda-builders)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/aws-lambda-builders)
+![pip](https://img.shields.io/badge/pip-aws--lambda--builders-9cf)
 
 Lambda Builders is a Python library to compile, build and package AWS Lambda functions for several runtimes & 
 frameworks.
@@ -12,8 +15,8 @@ Lambda Builders currently contains the following workflows
 * Dotnet with amazon.lambda.tools
 * Python with Pip
 * Javascript with Npm
+* Typescript with esbuild
 * Ruby with Bundler
-* Go with Dep
 * Go with Mod
 
 In Addition to above workflows, AWS Lambda Builders also supports *Custom Workflows* through a Makefile.


### PR DESCRIPTION
Badge changes;
- Current build badge doesn't reflect the actual status since we are only building for the PRs (not for the branch). And since there is now way to display build status for the latest PR, we are removing it.
- Adding license badge
- Adding latest version badge from GH releases
- Adding supported python versions badge from PyPI
- Adding library name for `pip` as static badge

Supported build changes;
- We removed `Go with Dep` with this PR: https://github.com/aws/aws-lambda-builders/pull/354
- Added latest esbuild support for Typescript


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
