### PR TITLE
fix: Fix failing esbuild integration tests

### DIFF
--- a/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
+++ b/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
@@ -32,6 +32,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
     def _set_esbuild_binary_path(self):
         npm = SubprocessNpm(self.osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
+        npm.run(["install"], cwd=esbuild_dir)
         self.root_path = npm.run(["root"], cwd=esbuild_dir)
         self.binpath = Path(self.root_path, ".bin")
 
@@ -168,6 +169,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         osutils = OSUtils()
         npm = SubprocessNpm(osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
+        npm.run(["install"], cwd=esbuild_dir)
         binpath = Path(npm.run(["root"], cwd=esbuild_dir), ".bin")
 
         self.builder.build(
@@ -193,6 +195,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         osutils = OSUtils()
         npm = SubprocessNpm(osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
+        npm.run(["install"], cwd=esbuild_dir)
         binpath = Path(npm.run(["root"], cwd=esbuild_dir), ".bin")
 
         self.builder.build(

--- a/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
+++ b/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
@@ -32,7 +32,6 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
     def _set_esbuild_binary_path(self):
         npm = SubprocessNpm(self.osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
-        npm.run(["ci"], cwd=esbuild_dir)
         self.root_path = npm.run(["root"], cwd=esbuild_dir)
         self.binpath = Path(self.root_path, ".bin")
 
@@ -169,7 +168,6 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         osutils = OSUtils()
         npm = SubprocessNpm(osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
-        npm.run(["ci"], cwd=esbuild_dir)
         binpath = Path(npm.run(["root"], cwd=esbuild_dir), ".bin")
 
         self.builder.build(
@@ -195,7 +193,6 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         osutils = OSUtils()
         npm = SubprocessNpm(osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
-        npm.run(["ci"], cwd=esbuild_dir)
         binpath = Path(npm.run(["root"], cwd=esbuild_dir), ".bin")
 
         self.builder.build(


### PR DESCRIPTION
*Issue #, if available:*
With npm version 9.3, the `npm ci` command now breaks when run. This seems like a bug with the newest version of npm. The `npm ci` command attempts to remove the existing `node_modules` directory but fails to do so if it contains a `.bin` directory, meaning and subsequent invocations of `npm ci` will fail. 

This PR replaces `npm ci` with `npm install` to unblock our integration tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
