### PR TITLE
add option to ignore files/dirs

### DIFF
--- a/aws_lambda_builders/actions.py
+++ b/aws_lambda_builders/actions.py
@@ -107,13 +107,16 @@ class CopySourceAction(BaseAction):
 
     PURPOSE = Purpose.COPY_SOURCE
 
-    def __init__(self, source_dir, dest_dir, excludes=None):
+    def __init__(self, source_dir, dest_dir, excludes=None, ignore=None):
         self.source_dir = source_dir
         self.dest_dir = dest_dir
         self.excludes = excludes or []
+        self.ignore = list(self.excludes)
+        if ignore and isinstance(ignore, (list, tuple)):
+            self.ignore += ignore
 
     def execute(self):
-        copytree(self.source_dir, self.dest_dir, ignore=shutil.ignore_patterns(*self.excludes))
+        copytree(self.source_dir, self.dest_dir, ignore=shutil.ignore_patterns(*self.ignore))
 
 
 class LinkSourceAction(BaseAction):

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -371,3 +371,6 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
                 Name=Action3, Purpose=COMPILE_SOURCE, Description=Compiles code
         """
         return "Workflow={}\nActions=\n\t{}".format(self.NAME, "\n\t".join(map(str, self.actions)))
+
+    def get_option(self, key, default=None):
+        return (self.options or {}).get(key, default)

--- a/aws_lambda_builders/workflows/custom_make/workflow.py
+++ b/aws_lambda_builders/workflows/custom_make/workflow.py
@@ -65,7 +65,9 @@ class CustomMakeWorkflow(BaseWorkflow):
 
         if not self.build_in_source:
             # if we're building on scratch_dir, we have to first copy the source there
-            self.actions.append(CopySourceAction(source_dir, scratch_dir, excludes=self.EXCLUDED_FILES))
+            self.actions.append(
+                CopySourceAction(source_dir, scratch_dir, excludes=self.EXCLUDED_FILES, ignore=options.get("ignore"))
+            )
 
         self.actions.append(make_action)
 

--- a/aws_lambda_builders/workflows/java_maven/workflow.py
+++ b/aws_lambda_builders/workflows/java_maven/workflow.py
@@ -47,7 +47,7 @@ class JavaMavenWorkflow(BaseWorkflow):
             copy_artifacts_action = JavaMavenCopyLayerArtifactsAction(scratch_dir, artifacts_dir, self.os_utils)
 
         self.actions = [
-            CopySourceAction(root_dir, scratch_dir, excludes=self.EXCLUDED_FILES),
+            CopySourceAction(root_dir, scratch_dir, excludes=self.EXCLUDED_FILES, ignore=self.get_option("ignore")),
             JavaMavenBuildAction(scratch_dir, subprocess_maven),
             JavaMavenCopyDependencyAction(scratch_dir, subprocess_maven),
             copy_artifacts_action,

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -56,7 +56,11 @@ class NodejsNpmWorkflow(BaseWorkflow):
 
         if not osutils.file_exists(manifest_path):
             LOG.warning("package.json file not found. Continuing the build without dependencies.")
-            self.actions = [CopySourceAction(source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES)]
+            self.actions = [
+                CopySourceAction(
+                    source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES, ignore=self.get_option("ignore")
+                )
+            ]
             return
 
         subprocess_npm = SubprocessNpm(osutils)
@@ -101,7 +105,9 @@ class NodejsNpmWorkflow(BaseWorkflow):
         actions = [
             npm_pack,
             npm_copy_npmrc_and_lockfile,
-            CopySourceAction(tar_package_dir, artifacts_dir, excludes=self.EXCLUDED_FILES),
+            CopySourceAction(
+                tar_package_dir, artifacts_dir, excludes=self.EXCLUDED_FILES, ignore=self.get_option("ignore")
+            ),
         ]
 
         if self.download_dependencies:

--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
@@ -104,8 +104,9 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
         :rtype: list
         :return: List of build actions to execute
         """
+        excludes: tuple[str] = self.EXCLUDED_FILES + tuple(["node_modules"])
         actions: List[BaseAction] = [
-            CopySourceAction(source_dir, scratch_dir, excludes=self.EXCLUDED_FILES + tuple(["node_modules"]))
+            CopySourceAction(source_dir, scratch_dir, excludes=excludes, ignore=self.get_option("ignore"))
         ]
 
         # Bundle dependencies separately in a dependency layer. We need to check the esbuild

--- a/aws_lambda_builders/workflows/python_pip/workflow.py
+++ b/aws_lambda_builders/workflows/python_pip/workflow.py
@@ -88,7 +88,11 @@ class PythonPipWorkflow(BaseWorkflow):
         self.actions = []
         if not osutils.file_exists(manifest_path):
             LOG.warning("requirements.txt file not found. Continuing the build without dependencies.")
-            self.actions.append(CopySourceAction(source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES))
+            self.actions.append(
+                CopySourceAction(
+                    source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES, ignore=self.get_option("ignore")
+                )
+            )
             return
 
         # If a requirements.txt exists, run pip builder before copy action.
@@ -118,7 +122,9 @@ class PythonPipWorkflow(BaseWorkflow):
             else:
                 self.actions.append(CopySourceAction(self.dependencies_dir, artifacts_dir))
 
-        self.actions.append(CopySourceAction(source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES))
+        self.actions.append(
+            CopySourceAction(source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES, ignore=self.get_option("ignore"))
+        )
 
     def get_resolvers(self):
         """

--- a/aws_lambda_builders/workflows/ruby_bundler/workflow.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/workflow.py
@@ -37,7 +37,9 @@ class RubyBundlerWorkflow(BaseWorkflow):
         if osutils is None:
             osutils = OSUtils()
 
-        self.actions = [CopySourceAction(source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES)]
+        self.actions = [
+            CopySourceAction(source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES, ignore=self.get_option("ignore"))
+        ]
 
         if self.download_dependencies:
             # installed the dependencies into artifact folder

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -397,3 +397,27 @@ class TestPythonPipWorkflow(TestCase):
         dependencies_files = set(os.listdir(self.dependencies_dir))
         for f in expected_dependencies_files:
             self.assertIn(f, dependencies_files)
+
+    def test_must_build_python_project_with_ignore(self):
+        ignore = {"main.py"}
+        self.builder.build(
+            self.source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            self.manifest_path_valid,
+            runtime=self.runtime,
+            experimental_flags=self.experimental_flags,
+            options={"ignore": list(ignore)},
+        )
+
+        if self.runtime == "python3.6":
+            self.check_architecture_in("numpy-1.17.4.dist-info", ["manylinux2010_x86_64", "manylinux1_x86_64"])
+            expected_files = self.test_data_files.difference(ignore).union({"numpy", "numpy-1.17.4.dist-info"})
+        else:
+            self.check_architecture_in("numpy-1.20.3.dist-info", ["manylinux2010_x86_64", "manylinux1_x86_64"])
+            expected_files = self.test_data_files.difference(ignore).union(
+                {"numpy", "numpy-1.20.3.dist-info", "numpy.libs"}
+            )
+
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)


### PR DESCRIPTION
adds a new option to all workflow builders: ignore specific files and directories

ex:
```
{
  options: { "ignore": [".build", ".tmp*"] }
}
```

fixes: #382 
fixes: #185 

And other numerous issues asking for a simple ignore feature

Added a test for python because I don't care for anything else right now.
But the feature is fully backwards compatible anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
