### PR TITLE
feat: Add support for mjs files with esbuild

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/esbuild.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/esbuild.py
@@ -120,6 +120,7 @@ SUPPORTED_ESBUILD_APIS_SINGLE_VALUE = [
 SUPPORTED_ESBUILD_APIS_MULTI_VALUE = [
     "external",
     "loader",
+    "out_extension",
 ]
 
 

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
@@ -220,7 +220,7 @@ class TestEsbuildCommandBuilder(TestCase):
                 "--external:axios",
                 "--loader:.proto=text",
                 "--loader:.json=js",
-                "--out-extension:.js=.mjs"
+                "--out-extension:.js=.mjs",
             ],
         )
 

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
@@ -200,6 +200,7 @@ class TestEsbuildCommandBuilder(TestCase):
             "target": "node14",
             "loader": [".proto=text", ".json=js"],
             "external": ["aws-sdk", "axios"],
+            "out_extension": [".js=.mjs"],
             "main_fields": "module,main",
         }
 
@@ -219,6 +220,7 @@ class TestEsbuildCommandBuilder(TestCase):
                 "--external:axios",
                 "--loader:.proto=text",
                 "--loader:.json=js",
+                "--out-extension:.js=.mjs"
             ],
         )
 


### PR DESCRIPTION
*Issue #, if available:*
#426
*Description of changes:*
Add support for the `--out-extension` flag for producing `.mjs` files to take advantage of es modules support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
