### PR TITLE
refactor: assign each workflow a default build directory

### DIFF
--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -38,10 +38,12 @@ class BuildMode(object):
     DEBUG = "debug"
     RELEASE = "release"
 
+
 class BuildDirectory(Enum):
     SCRATCH = "scratch"
     ARTIFACTS = "artifacts"
     SOURCE = "source"
+
 
 class BuildInSourceSupport(Enum):
     """
@@ -147,15 +149,11 @@ class _WorkflowMetaClass(type):
 
         # All workflows must define supported values for build in source
         if not isinstance(cls.BUILD_IN_SOURCE_SUPPORT, BuildInSourceSupport):
-            raise ValueError(
-                "Workflow '{}' must define supported values for build in source".format(cls.NAME)
-            )
+            raise ValueError("Workflow '{}' must define supported values for build in source".format(cls.NAME))
 
         # All workflows must define default build directory
         if not isinstance(cls.DEFAULT_BUILD_DIR, BuildDirectory):
-            raise ValueError(
-                "Workflow '{}' must define default build directory".format(cls.NAME)
-            )
+            raise ValueError("Workflow '{}' must define default build directory".format(cls.NAME))
 
         LOG.debug("Registering workflow '%s' with capability '%s'", cls.NAME, cls.CAPABILITY)
         DEFAULT_REGISTRY[cls.CAPABILITY] = cls
@@ -274,7 +272,6 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
         self.actions = []
         self._binaries = {}
 
-
     def _select_build_dir(self, build_in_source: Optional[bool]) -> str:
         """
         Returns the build directory for the workflow.
@@ -284,7 +281,7 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
         if build_in_source not in self.BUILD_IN_SOURCE_SUPPORT.value:
             # assign default value
             should_build_in_source = self.DEFAULT_BUILD_DIR == BuildDirectory.SOURCE
-            
+
             # only show warning if an unsupported value was explicitly passed in
             if build_in_source is not None:
                 LOG.warning(

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -266,6 +266,8 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
         self.architecture = architecture
         self.is_building_layer = is_building_layer
         self.experimental_flags = experimental_flags if experimental_flags else []
+
+        # this represents where the build/install happens, not the final output directory (that's the artifacts_dir)
         self.build_dir = self._select_build_dir(build_in_source)
 
         # Actions are registered by the subclasses as they seem fit

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -145,13 +145,13 @@ class _WorkflowMetaClass(type):
         if not isinstance(cls.CAPABILITY, Capability):
             raise ValueError("Workflow '{}' must register valid capabilities".format(cls.NAME))
 
-        # All workflows define supported values for build in source
+        # All workflows must define supported values for build in source
         if not isinstance(cls.BUILD_IN_SOURCE_SUPPORT, BuildInSourceSupport):
             raise ValueError(
                 "Workflow '{}' must define supported values for build in source".format(cls.NAME)
             )
 
-        # All workflows define default build directory
+        # All workflows must define default build directory
         if not isinstance(cls.DEFAULT_BUILD_DIR, BuildDirectory):
             raise ValueError(
                 "Workflow '{}' must define default build directory".format(cls.NAME)

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -182,7 +182,7 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
     # Support for building in source, each workflow should define this.
     BUILD_IN_SOURCE_SUPPORT = None
 
-    # Default build directory, each workflow should define this.
+    # The directory where the workflow builds/installs by default, each workflow should define this.
     DEFAULT_BUILD_DIR = None
 
     def __init__(

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -7,6 +7,7 @@ import logging
 
 from collections import namedtuple
 from enum import Enum
+from typing import Dict, Optional
 
 from aws_lambda_builders.binary_path import BinaryPath
 from aws_lambda_builders.path_resolver import PathResolver
@@ -37,6 +38,10 @@ class BuildMode(object):
     DEBUG = "debug"
     RELEASE = "release"
 
+class BuildDirectory(Enum):
+    SCRATCH = "scratch"
+    ARTIFACTS = "artifacts"
+    SOURCE = "source"
 
 class BuildInSourceSupport(Enum):
     """
@@ -140,13 +145,16 @@ class _WorkflowMetaClass(type):
         if not isinstance(cls.CAPABILITY, Capability):
             raise ValueError("Workflow '{}' must register valid capabilities".format(cls.NAME))
 
-        # All workflows must define valid default and supported values for build in source
-        if (
-            not isinstance(cls.BUILD_IN_SOURCE_SUPPORT, BuildInSourceSupport)
-            or cls.BUILD_IN_SOURCE_BY_DEFAULT not in cls.BUILD_IN_SOURCE_SUPPORT.value
-        ):
+        # All workflows define supported values for build in source
+        if not isinstance(cls.BUILD_IN_SOURCE_SUPPORT, BuildInSourceSupport):
             raise ValueError(
-                "Workflow '{}' must define valid default and supported values for build in source".format(cls.NAME)
+                "Workflow '{}' must define supported values for build in source".format(cls.NAME)
+            )
+
+        # All workflows define default build directory
+        if not isinstance(cls.DEFAULT_BUILD_DIR, BuildDirectory):
+            raise ValueError(
+                "Workflow '{}' must define default build directory".format(cls.NAME)
             )
 
         LOG.debug("Registering workflow '%s' with capability '%s'", cls.NAME, cls.CAPABILITY)
@@ -173,11 +181,11 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
     # Optional list of manifests file/folder names supported by this workflow.
     SUPPORTED_MANIFESTS = []
 
-    # Whether the workflow builds in source by default, each workflow should define this.
-    # (some workflows build in temporary or artifact directories by default)
-    BUILD_IN_SOURCE_BY_DEFAULT = None
     # Support for building in source, each workflow should define this.
     BUILD_IN_SOURCE_SUPPORT = None
+
+    # Default build directory, each workflow should define this.
+    DEFAULT_BUILD_DIR = None
 
     def __init__(
         self,
@@ -260,22 +268,39 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
         self.architecture = architecture
         self.is_building_layer = is_building_layer
         self.experimental_flags = experimental_flags if experimental_flags else []
+        self.build_dir = self._select_build_dir(build_in_source)
 
-        self.build_in_source = build_in_source
+        # Actions are registered by the subclasses as they seem fit
+        self.actions = []
+        self._binaries = {}
+
+
+    def _select_build_dir(self, build_in_source: Optional[bool]) -> str:
+        """
+        Returns the build directory for the workflow.
+        """
+
+        should_build_in_source = build_in_source
         if build_in_source not in self.BUILD_IN_SOURCE_SUPPORT.value:
+            # assign default value
+            should_build_in_source = self.DEFAULT_BUILD_DIR == BuildDirectory.SOURCE
+            
             # only show warning if an unsupported value was explicitly passed in
             if build_in_source is not None:
                 LOG.warning(
                     'Workflow %s does not support value "%s" for building in source. Using default value "%s".',
                     self.NAME,
                     build_in_source,
-                    self.BUILD_IN_SOURCE_BY_DEFAULT,
+                    should_build_in_source,
                 )
-            self.build_in_source = self.BUILD_IN_SOURCE_BY_DEFAULT
 
-        # Actions are registered by the subclasses as they seem fit
-        self.actions = []
-        self._binaries = {}
+        build_directory_mapping = {
+            BuildDirectory.SCRATCH: self.scratch_dir,
+            BuildDirectory.ARTIFACTS: self.artifacts_dir,
+            BuildDirectory.SOURCE: self.source_dir,
+        }
+
+        return self.source_dir if should_build_in_source else build_directory_mapping.get(self.DEFAULT_BUILD_DIR)
 
     def is_supported(self):
         """

--- a/aws_lambda_builders/workflows/custom_make/workflow.py
+++ b/aws_lambda_builders/workflows/custom_make/workflow.py
@@ -46,7 +46,7 @@ class CustomMakeWorkflow(BaseWorkflow):
 
         subprocess_make = SubProcessMake(make_exe=self.binaries["make"].binary_path, osutils=self.os_utils)
 
-        # an explicitly definied working directory should take precedence
+        # an explicitly defined working directory should take precedence
         working_directory = options.get("working_directory") or self.build_dir
 
         make_action = CustomMakeAction(
@@ -60,9 +60,9 @@ class CustomMakeWorkflow(BaseWorkflow):
 
         self.actions = []
 
-        if working_directory != source_dir:
+        if self.build_dir != source_dir:
             # if we're not building in the source directory, we have to first copy the source
-            self.actions.append(CopySourceAction(source_dir, working_directory, excludes=self.EXCLUDED_FILES))
+            self.actions.append(CopySourceAction(source_dir, self.build_dir, excludes=self.EXCLUDED_FILES))
 
         self.actions.append(make_action)
 

--- a/aws_lambda_builders/workflows/custom_make/workflow.py
+++ b/aws_lambda_builders/workflows/custom_make/workflow.py
@@ -2,7 +2,7 @@
 ProvidedMakeWorkflow
 """
 from aws_lambda_builders.workflows.custom_make.validator import CustomMakeRuntimeValidator
-from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
+from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport, BuildDirectory
 from aws_lambda_builders.actions import CopySourceAction
 from aws_lambda_builders.path_resolver import PathResolver
 from .actions import CustomMakeAction
@@ -23,7 +23,7 @@ class CustomMakeWorkflow(BaseWorkflow):
 
     EXCLUDED_FILES = (".aws-sam", ".git")
 
-    BUILD_IN_SOURCE_BY_DEFAULT = False
+    DEFAULT_BUILD_DIR = BuildDirectory.SCRATCH
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):
@@ -35,7 +35,6 @@ class CustomMakeWorkflow(BaseWorkflow):
         self.os_utils = OSUtils()
 
         options = kwargs.get("options") or {}
-        build_in_source = kwargs.get("build_in_source")
 
         build_logical_id = options.get("build_logical_id", None)
         if not build_logical_id:
@@ -48,9 +47,7 @@ class CustomMakeWorkflow(BaseWorkflow):
         subprocess_make = SubProcessMake(make_exe=self.binaries["make"].binary_path, osutils=self.os_utils)
 
         # an explicitly definied working directory should take precedence
-        working_directory = options.get("working_directory") or self._select_working_directory(
-            source_dir, scratch_dir, build_in_source
-        )
+        working_directory = options.get("working_directory") or self.build_dir
 
         make_action = CustomMakeAction(
             artifacts_dir,
@@ -63,17 +60,11 @@ class CustomMakeWorkflow(BaseWorkflow):
 
         self.actions = []
 
-        if not self.build_in_source:
-            # if we're building on scratch_dir, we have to first copy the source there
-            self.actions.append(CopySourceAction(source_dir, scratch_dir, excludes=self.EXCLUDED_FILES))
+        if working_directory != source_dir:
+            # if we're not building in the source directory, we have to first copy the source
+            self.actions.append(CopySourceAction(source_dir, working_directory, excludes=self.EXCLUDED_FILES))
 
         self.actions.append(make_action)
-
-    def _select_working_directory(self, source_dir: str, scratch_dir: str, build_in_source: bool):
-        """
-        Returns the directory where the make action should be executed
-        """
-        return source_dir if build_in_source else scratch_dir
 
     def get_resolvers(self):
         return [PathResolver(runtime="provided", binary="make", executable_search_paths=self.executable_search_paths)]

--- a/aws_lambda_builders/workflows/dotnet_clipackage/workflow.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/workflow.py
@@ -1,7 +1,7 @@
 """
 .NET Core CLI Package Workflow
 """
-from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, Capability, BuildInSourceSupport
 
 from .actions import GlobalToolInstallAction, RunPackageAction
 from .dotnetcli import SubprocessDotnetCLI
@@ -19,7 +19,7 @@ class DotnetCliPackageWorkflow(BaseWorkflow):
 
     CAPABILITY = Capability(language="dotnet", dependency_manager="cli-package", application_framework=None)
 
-    BUILD_IN_SOURCE_BY_DEFAULT = True
+    DEFAULT_BUILD_DIR = BuildDirectory.SOURCE
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.EXCLUSIVELY_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, mode=None, **kwargs):

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -1,7 +1,7 @@
 """
 Go Modules Workflow
 """
-from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, Capability, BuildInSourceSupport
 
 from .actions import GoModulesBuildAction
 from .builder import GoModulesBuilder
@@ -15,7 +15,7 @@ class GoModulesWorkflow(BaseWorkflow):
 
     CAPABILITY = Capability(language="go", dependency_manager="modules", application_framework=None)
 
-    BUILD_IN_SOURCE_BY_DEFAULT = True
+    DEFAULT_BUILD_DIR = BuildDirectory.SOURCE
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.EXCLUSIVELY_SUPPORTED
 
     def __init__(

--- a/aws_lambda_builders/workflows/java_gradle/workflow.py
+++ b/aws_lambda_builders/workflows/java_gradle/workflow.py
@@ -4,7 +4,7 @@ Java Gradle Workflow
 import hashlib
 import os
 from aws_lambda_builders.actions import CleanUpAction
-from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, Capability, BuildInSourceSupport
 from aws_lambda_builders.workflows.java.actions import JavaCopyDependenciesAction, JavaMoveDependenciesAction
 from aws_lambda_builders.workflows.java.utils import OSUtils
 
@@ -25,7 +25,7 @@ class JavaGradleWorkflow(BaseWorkflow):
 
     INIT_FILE = "lambda-build-init.gradle"
 
-    BUILD_IN_SOURCE_BY_DEFAULT = False
+    DEFAULT_BUILD_DIR = BuildDirectory.SCRATCH
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, **kwargs):

--- a/aws_lambda_builders/workflows/java_maven/workflow.py
+++ b/aws_lambda_builders/workflows/java_maven/workflow.py
@@ -1,7 +1,7 @@
 """
 Java Maven Workflow
 """
-from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, Capability, BuildInSourceSupport
 from aws_lambda_builders.actions import CopySourceAction, CleanUpAction
 from aws_lambda_builders.workflows.java.actions import JavaCopyDependenciesAction, JavaMoveDependenciesAction
 from aws_lambda_builders.workflows.java.utils import OSUtils
@@ -28,7 +28,7 @@ class JavaMavenWorkflow(BaseWorkflow):
 
     EXCLUDED_FILES = (".aws-sam", ".git")
 
-    BUILD_IN_SOURCE_BY_DEFAULT = False
+    DEFAULT_BUILD_DIR = BuildDirectory.SCRATCH
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, **kwargs):

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -5,7 +5,7 @@ NodeJS NPM Workflow
 import logging
 
 from aws_lambda_builders.path_resolver import PathResolver
-from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, Capability, BuildInSourceSupport
 from aws_lambda_builders.actions import (
     CopySourceAction,
     CleanUpAction,
@@ -42,7 +42,7 @@ class NodejsNpmWorkflow(BaseWorkflow):
 
     CONFIG_PROPERTY = "aws_sam"
 
-    BUILD_IN_SOURCE_BY_DEFAULT = False
+    DEFAULT_BUILD_DIR = BuildDirectory.ARTIFACTS
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):

--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import List
 
-from aws_lambda_builders.workflow import BaseWorkflow, Capability, BuildInSourceSupport
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, Capability, BuildInSourceSupport
 from aws_lambda_builders.actions import (
     CopySourceAction,
     CleanUpAction,
@@ -44,7 +44,7 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
 
     CONFIG_PROPERTY = "aws_sam"
 
-    BUILD_IN_SOURCE_BY_DEFAULT = False
+    DEFAULT_BUILD_DIR = BuildDirectory.SCRATCH
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):

--- a/aws_lambda_builders/workflows/python_pip/workflow.py
+++ b/aws_lambda_builders/workflows/python_pip/workflow.py
@@ -3,7 +3,7 @@ Python PIP Workflow
 """
 import logging
 
-from aws_lambda_builders.workflow import BaseWorkflow, BuildInSourceSupport, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, BuildInSourceSupport, Capability
 from aws_lambda_builders.actions import CopySourceAction, CleanUpAction, LinkSourceAction
 from aws_lambda_builders.workflows.python_pip.validator import PythonRuntimeValidator
 from aws_lambda_builders.path_resolver import PathResolver
@@ -67,7 +67,7 @@ class PythonPipWorkflow(BaseWorkflow):
 
     PYTHON_VERSION_THREE = "3"
 
-    BUILD_IN_SOURCE_BY_DEFAULT = False
+    DEFAULT_BUILD_DIR = BuildDirectory.SCRATCH
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):

--- a/aws_lambda_builders/workflows/ruby_bundler/workflow.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/workflow.py
@@ -3,7 +3,7 @@ Ruby Bundler Workflow
 """
 import logging
 
-from aws_lambda_builders.workflow import BaseWorkflow, BuildInSourceSupport, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, BuildInSourceSupport, Capability
 from aws_lambda_builders.actions import CopySourceAction, CopyDependenciesAction, CleanUpAction
 from .actions import RubyBundlerInstallAction, RubyBundlerVendorAction
 from .utils import OSUtils
@@ -25,7 +25,7 @@ class RubyBundlerWorkflow(BaseWorkflow):
 
     EXCLUDED_FILES = (".aws-sam", ".git")
 
-    BUILD_IN_SOURCE_BY_DEFAULT = False
+    DEFAULT_BUILD_DIR = BuildDirectory.ARTIFACTS
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.NOT_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=None, osutils=None, **kwargs):

--- a/tests/functional/testdata/workflows/hello_workflow/write_hello.py
+++ b/tests/functional/testdata/workflows/hello_workflow/write_hello.py
@@ -4,7 +4,7 @@ Provides a test workflow and action that writes a file to artifacts called hello
 
 import os
 
-from aws_lambda_builders.workflow import BaseWorkflow, BuildInSourceSupport, Capability
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, BuildInSourceSupport, Capability
 from aws_lambda_builders.actions import BaseAction, Purpose
 
 
@@ -34,7 +34,7 @@ class WriteHelloWorkflow(BaseWorkflow):
 
     NAME = "WriteHelloWorkflow"
     CAPABILITY = Capability(language="python", dependency_manager="test", application_framework="test")
-    BUILD_IN_SOURCE_BY_DEFAULT = False
+    DEFAULT_BUILD_DIR = BuildDirectory.SCRATCH
     BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
     def __init__(self, source_dir, artifacts_dir, *args, **kwargs):

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -4,7 +4,7 @@ from mock import patch, call, Mock
 from parameterized import parameterized, param
 
 from aws_lambda_builders.builder import LambdaBuilder
-from aws_lambda_builders.workflow import BuildInSourceSupport, Capability, BaseWorkflow
+from aws_lambda_builders.workflow import BuildDirectory, BuildInSourceSupport, Capability, BaseWorkflow
 from aws_lambda_builders.registry import DEFAULT_REGISTRY
 
 
@@ -71,7 +71,7 @@ class TesetLambdaBuilder_init(TestCase):
             CAPABILITY = Capability(
                 language=self.lang, dependency_manager=self.lang_framework, application_framework=self.app_framework
             )
-            BUILD_IN_SOURCE_BY_DEFAULT = False
+            DEFAULT_BUILD_DIR = BuildDirectory.SCRATCH
             BUILD_IN_SOURCE_SUPPORT = BuildInSourceSupport.OPTIONALLY_SUPPORTED
 
             def __init__(

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -475,7 +475,7 @@ class TestBaseWorkflow_build_in_source(TestCase):
             executable_search_paths=[str(sys.executable)],
             optimizations={"a": "b"},
             options={"c": "d"},
-            build_in_source=True
+            build_in_source=True,
         )
 
         self.assertEqual(self.work.build_dir, source_dir)
@@ -487,9 +487,7 @@ class TestBaseWorkflow_build_in_source(TestCase):
             (BuildDirectory.ARTIFACTS, "artifacts_dir"),
         ]
     )
-    def test_must_use_correct_default_value(
-        self, default_build_dir, expected_build_dir
-    ):
+    def test_must_use_correct_default_value(self, default_build_dir, expected_build_dir):
         class MyWorkflow(BaseWorkflow):
             __TESTING__ = True
             NAME = "MyWorkflow"
@@ -514,14 +512,24 @@ class TestBaseWorkflow_build_in_source(TestCase):
 
     @parameterized.expand(
         [
-            (True, BuildInSourceSupport.NOT_SUPPORTED, BuildDirectory.SCRATCH, "scratch_dir"),  # want to build in source but it's not supported
+            (
+                True,
+                BuildInSourceSupport.NOT_SUPPORTED,
+                BuildDirectory.SCRATCH,
+                "scratch_dir",
+            ),  # want to build in source but it's not supported
             (
                 False,
                 BuildInSourceSupport.EXCLUSIVELY_SUPPORTED,
                 BuildDirectory.SOURCE,
-                "source_dir"
+                "source_dir",
             ),  # don't want to build in source but workflow requires it
-            ("unsupported", BuildInSourceSupport.OPTIONALLY_SUPPORTED, BuildDirectory.ARTIFACTS, "artifacts_dir"),  # unsupported value passed in
+            (
+                "unsupported",
+                BuildInSourceSupport.OPTIONALLY_SUPPORTED,
+                BuildDirectory.ARTIFACTS,
+                "artifacts_dir",
+            ),  # unsupported value passed in
         ]
     )
     def test_must_use_default_if_unsupported_value_is_provided(

--- a/tests/unit/workflows/custom_make/test_workflow.py
+++ b/tests/unit/workflows/custom_make/test_workflow.py
@@ -93,6 +93,7 @@ class TestProvidedMakeWorkflow(TestCase):
             build_in_source=True,
         )
 
-        self.assertEqual(len(workflow.actions), 1)
-        self.assertIsInstance(workflow.actions[0], CustomMakeAction)
-        self.assertEqual(workflow.actions[0].working_directory, working_dir)
+        self.assertEqual(len(workflow.actions), 2)
+        # since it's going to build in a custom working directory, should copy the source there first
+        self.assertIsInstance(workflow.actions[0], CopySourceAction)
+        self.assertEqual(workflow.actions[1].working_directory, working_dir)

--- a/tests/unit/workflows/custom_make/test_workflow.py
+++ b/tests/unit/workflows/custom_make/test_workflow.py
@@ -93,7 +93,6 @@ class TestProvidedMakeWorkflow(TestCase):
             build_in_source=True,
         )
 
-        self.assertEqual(len(workflow.actions), 2)
-        # since it's going to build in a custom working directory, should copy the source there first
-        self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        self.assertEqual(workflow.actions[1].working_directory, working_dir)
+        self.assertEqual(len(workflow.actions), 1)
+        self.assertIsInstance(workflow.actions[0], CustomMakeAction)
+        self.assertEqual(workflow.actions[0].working_directory, working_dir)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A recent change (https://github.com/aws/aws-lambda-builders/pull/418) added `BUILD_IN_SOURCE_BY_DEFAULT` to each workflow. This PR replaces that with `DEFAULT_BUILD_DIR`, which helps us generalize some logic more. We can now set and use a workflow's `build_dir` property using a combination of:
- the value of the `build_in_source` parameter passed in to lambda builders
  - if user wants to build in source, the build directory should be set to the source directory
- the workflow's default build directory (`DEFAULT_BUILD_DIR`)
  - in case `build_in_source` is not set, or it's set to `False`, or an unsupported value is passed in, we should use the workflow's existing default build directory

Note that we're still able to find out if a workflow builds in source by default just by checking if their `DEFAULT_BUILD_DIR` is the source directory. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
