### PR TITLE
fix: remove unused symlinking in esbuild workflow

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
@@ -175,7 +175,6 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
                 actions += [
                     esbuild_with_deps,
                     MoveDependenciesAction(source_dir, scratch_dir, self.dependencies_dir),
-                    LinkSourceAction(self.dependencies_dir, scratch_dir),
                 ]
             else:
                 # Auto dependency layer enabled, first build

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
@@ -265,14 +265,13 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             experimental_flags=[],
         )
 
-        self.assertEqual(len(workflow.actions), 6)
+        self.assertEqual(len(workflow.actions), 5)
 
         self.assertIsInstance(workflow.actions[0], CopySourceAction)
         self.assertIsInstance(workflow.actions[1], NodejsNpmInstallAction)
         self.assertIsInstance(workflow.actions[2], CleanUpAction)
         self.assertIsInstance(workflow.actions[3], EsbuildBundleAction)
         self.assertIsInstance(workflow.actions[4], MoveDependenciesAction)
-        self.assertIsInstance(workflow.actions[5], LinkSourceAction)
 
     def test_workflow_sets_up_esbuild_actions_with_download_dependencies_and_dependencies_dir_no_combine_deps(self):
         workflow = NodejsNpmEsbuildWorkflow(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the esbuild workflow, symlinking is needed when we are not installing dependencies and we already have a dependencies_dir, so that we can symlink that dependencies_dir (node_modules) before bundling. 

However, there's another part of the code that does symlinking when we already installed dependencies and we already bundled, so it shouldn't be necessary here. Moreover this symlink is created in the scratch directory, so it won't persist anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
