### PR TITLE
chore: Enable pylint within ruff

### DIFF
--- a/aws_lambda_builders/workflows/dotnet_clipackage/utils.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/utils.py
@@ -72,8 +72,8 @@ class OSUtils(object):
         bool
             A response regarding whether the ZipInfo defines a symlink or not.
         """
-
-        return (file_info.external_attr >> 28) == 0xA
+        symlink = 0xA
+        return (file_info.external_attr >> 28) == symlink
 
     def _extract(self, file_info, output_dir, zip_ref):
         """

--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -18,7 +18,8 @@ def pip_import_string(python_exe):
     # Pip moved its internals to an _internal module in version 10.
     # In order to be compatible with version 9 which has it at at the
     # top level we need to figure out the correct import path here.
-    if pip_major_version == 9:
+    pip_version_9 = 9
+    if pip_major_version == pip_version_9:
         return "from pip import main"
     # Pip changed their import structure again in 19.3
     # https://github.com/pypa/pip/commit/09fd200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ select = [
     "F",  # Pyflakes
     "PL", # pylint
 ]
+ignore = ["PLR0913"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401", "E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [tool.ruff]
 line-length = 120
 
+select = [
+    "E",  # Pycodestyle
+    "F",  # Pyflakes
+    "PL", # pylint
+]
+
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401", "E501"]
 "aws_lambda_builders/workflow.py" = ["E501"]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In #435, I added `ruff` to replace `pylint` linting. However, I missed that `ruff` does not add `pylint` in by default (only pycodestyle and Pyflakes. This PR targets `pylint` rules ruff has.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
