### PR TITLE
feat: use build_dir in esbuild workflow to support building in source

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -81,11 +81,10 @@ class NodejsNpmInstallAction(BaseAction):
     DESCRIPTION = "Installing dependencies from NPM"
     PURPOSE = Purpose.RESOLVE_DEPENDENCIES
 
-    def __init__(self, artifacts_dir, subprocess_npm):
+    def __init__(self, install_dir, subprocess_npm):
         """
-        :type artifacts_dir: str
-        :param artifacts_dir: an existing (writable) directory with project source files.
-            Dependencies will be installed in this directory.
+        :type install_dir: str
+        :param install_dir: Dependencies will be installed in this directory.
 
         :type subprocess_npm: aws_lambda_builders.workflows.nodejs_npm.npm.SubprocessNpm
         :param subprocess_npm: An instance of the NPM process wrapper
@@ -95,7 +94,7 @@ class NodejsNpmInstallAction(BaseAction):
         """
 
         super(NodejsNpmInstallAction, self).__init__()
-        self.artifacts_dir = artifacts_dir
+        self.install_dir = install_dir
         self.subprocess_npm = subprocess_npm
 
     def execute(self):
@@ -105,10 +104,10 @@ class NodejsNpmInstallAction(BaseAction):
         :raises lambda_builders.actions.ActionFailedError: when NPM execution fails
         """
         try:
-            LOG.debug("NODEJS installing in: %s", self.artifacts_dir)
+            LOG.debug("NODEJS installing in: %s", self.install_dir)
 
             self.subprocess_npm.run(
-                ["install", "-q", "--no-audit", "--no-save", "--unsafe-perm", "--production"], cwd=self.artifacts_dir
+                ["install", "-q", "--no-audit", "--no-save", "--unsafe-perm", "--production"], cwd=self.install_dir
             )
 
         except NpmExecutionError as ex:
@@ -128,18 +127,17 @@ class NodejsNpmCIAction(BaseAction):
     DESCRIPTION = "Installing dependencies from NPM using the CI method"
     PURPOSE = Purpose.RESOLVE_DEPENDENCIES
 
-    def __init__(self, artifacts_dir, subprocess_npm):
+    def __init__(self, install_dir, subprocess_npm):
         """
-        :type artifacts_dir: str
-        :param artifacts_dir: an existing (writable) directory with project source files.
-            Dependencies will be installed in this directory.
+        :type install_dir: str
+        :param install_dir: Dependencies will be installed in this directory.
 
         :type subprocess_npm: aws_lambda_builders.workflows.nodejs_npm.npm.SubprocessNpm
         :param subprocess_npm: An instance of the NPM process wrapper
         """
 
         super(NodejsNpmCIAction, self).__init__()
-        self.artifacts_dir = artifacts_dir
+        self.install_dir = install_dir
         self.subprocess_npm = subprocess_npm
 
     def execute(self):
@@ -150,9 +148,9 @@ class NodejsNpmCIAction(BaseAction):
         """
 
         try:
-            LOG.debug("NODEJS installing ci in: %s", self.artifacts_dir)
+            LOG.debug("NODEJS installing ci in: %s", self.install_dir)
 
-            self.subprocess_npm.run(["ci"], cwd=self.artifacts_dir)
+            self.subprocess_npm.run(["ci"], cwd=self.install_dir)
 
         except NpmExecutionError as ex:
             raise ActionFailedError(str(ex))

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -148,15 +148,15 @@ class NodejsNpmWorkflow(BaseWorkflow):
         return [PathResolver(runtime=self.runtime, binary="npm")]
 
     @staticmethod
-    def get_install_action(source_dir, artifacts_dir, subprocess_npm, osutils, build_options):
+    def get_install_action(source_dir, install_dir, subprocess_npm, osutils, build_options):
         """
         Get the install action used to install dependencies at artifacts_dir
 
         :type source_dir: str
         :param source_dir: an existing (readable) directory containing source files
 
-        :type artifacts_dir: str
-        :param artifacts_dir: Dependencies will be installed in this directory.
+        :type install_dir: str
+        :param install_dir: Dependencies will be installed in this directory.
 
         :type osutils: aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils
         :param osutils: An instance of OS Utilities for file manipulation
@@ -181,6 +181,6 @@ class NodejsNpmWorkflow(BaseWorkflow):
             npm_ci_option = build_options.get("use_npm_ci", False)
 
         if (osutils.file_exists(lockfile_path) or osutils.file_exists(shrinkwrap_path)) and npm_ci_option:
-            return NodejsNpmCIAction(artifacts_dir, subprocess_npm=subprocess_npm)
+            return NodejsNpmCIAction(install_dir=install_dir, subprocess_npm=subprocess_npm)
 
-        return NodejsNpmInstallAction(artifacts_dir, subprocess_npm=subprocess_npm)
+        return NodejsNpmInstallAction(install_dir=install_dir, subprocess_npm=subprocess_npm)

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
@@ -313,7 +313,7 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
         self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
 
         get_workflow_mock.get_install_action.assert_called_with(
-            source_dir="source", artifacts_dir="scratch_dir", subprocess_npm=ANY, osutils=ANY, build_options=None
+            source_dir="source", install_dir="scratch_dir", subprocess_npm=ANY, osutils=ANY, build_options=None
         )
 
     @patch("aws_lambda_builders.workflows.nodejs_npm_esbuild.workflow.SubprocessNpm")
@@ -342,3 +342,21 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
                 osutils=self.osutils,
                 download_dependencies=False,
             )
+
+    def test_build_in_source(self):
+        source_dir = "source"
+        workflow = NodejsNpmEsbuildWorkflow(
+            source_dir=source_dir,
+            artifacts_dir="artifacts",
+            scratch_dir="scratch_dir",
+            manifest_path="manifest",
+            osutils=self.osutils,
+            build_in_source=True,
+        )
+
+        self.assertEqual(len(workflow.actions), 2)
+
+        self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
+        self.assertEqual(workflow.actions[0].install_dir, source_dir)
+        self.assertIsInstance(workflow.actions[1], EsbuildBundleAction)
+        self.assertEqual(workflow.actions[1]._working_directory, source_dir)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now that `build_dir` will point to either the source directory, if building in source, or the workflow's default build directory, we can refactor the workflow to use `build_dir` and it will enable build-in-source support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
