### PR TITLE
feat: Add sources content flag to supported esbuild options

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/esbuild.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/esbuild.py
@@ -114,6 +114,7 @@ SUPPORTED_ESBUILD_APIS_SINGLE_VALUE = [
     "target",
     "format",
     "main_fields",
+    "sources_content",
 ]
 
 # Multi-value types (--external:axios --external:aws-sdk)

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
@@ -196,6 +196,7 @@ class TestEsbuildCommandBuilder(TestCase):
         bundler_config = {
             "minify": True,
             "sourcemap": False,
+            "sources_content": "false",
             "format": "esm",
             "target": "node14",
             "loader": [".proto=text", ".json=js"],
@@ -216,6 +217,7 @@ class TestEsbuildCommandBuilder(TestCase):
                 "--target=node14",
                 "--format=esm",
                 "--main-fields=module,main",
+                "--sources-content=false",
                 "--external:aws-sdk",
                 "--external:axios",
                 "--loader:.proto=text",


### PR DESCRIPTION
*Issue #, if available:*
#438

*Description of changes:*
Add support for the `--sources-content=false` option to create much more lightweight production sourcemaps that don't include the source code.

This change will require a documentation update.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
