### PR TITLE
feat: Pin ruff version, add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: chore
+      include: scope
+    reviewers:
+      - aws/serverless-application-experience-sbt
+
+  - package-ecosystem: "pip"
+    directory: "/requirements"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    commit-message:
+      prefix: chore
+      include: scope
+    reviewers:
+      -  aws/serverless-application-experience-sbt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
       include: scope
     reviewers:
       -  aws/serverless-application-experience-sbt
+    ignore:
+      # The dependencies are intentionally pinned to certain
+      # version ranges for specific Python versions
+      - dependency-name: "flake8"
+      - dependency-name: "isort"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,4 +13,4 @@ pyelftools~=0.27 # Used to verify the generated Go binary architecture in integr
 
 # formatter
 black==22.3.0
-ruff
+ruff==0.0.238


### PR DESCRIPTION
*Description of changes:*
- Pins the ruff version to ensure our CI jobs don't break unexpectedly
- Adds a `dependabot` config that runs weekly to check for newer dependency versions and raises a PR accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
