### PR TITLE
chore: Remove unneeded mock dependency

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,6 @@ isort>=4.2.5,<5; python_version < '3.8'
 
 # Test requirements
 pytest>=6.1.1
-mock==4.0.2
 parameterized==0.7.4
 pyelftools~=0.27 # Used to verify the generated Go binary architecture in integration tests (utils.py)
 

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -78,7 +78,7 @@ class TestExtractTarFile(TestCase):
         tar_filename = "path_reversal_win.tgz" if platform.system().lower() == "windows" else "path_reversal_uxix.tgz"
         test_tar = os.path.join(os.path.dirname(__file__), "testdata", tar_filename)
         test_dir = tempfile.mkdtemp()
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ExtractError, "Attempted Path Traversal in Tar File", extract_tarfile, test_tar, test_dir
         )
 

--- a/tests/functional/workflows/python_pip/test_packager.py
+++ b/tests/functional/workflows/python_pip/test_packager.py
@@ -4,9 +4,9 @@ import zipfile
 import tarfile
 import io
 from collections import defaultdict, namedtuple
+from unittest import mock
 
 import pytest
-import mock
 
 from aws_lambda_builders.architecture import ARM64
 from aws_lambda_builders.workflows.python_pip.packager import PipRunner, UnsupportedPackageError

--- a/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
+++ b/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
@@ -3,9 +3,8 @@ import os
 import shutil
 import tempfile
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
-import mock
 from parameterized import parameterized
 
 from aws_lambda_builders.builder import LambdaBuilder

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -4,8 +4,8 @@ import shutil
 import sys
 import platform
 import tempfile
-from unittest import TestCase, skipIf
-import mock
+from unittest import TestCase, skipIf, mock
+
 from parameterized import parameterized_class
 
 from aws_lambda_builders.builder import LambdaBuilder

--- a/tests/integration/workflows/ruby_bundler/test_ruby.py
+++ b/tests/integration/workflows/ruby_bundler/test_ruby.py
@@ -2,12 +2,11 @@ import os
 import shutil
 import tempfile
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from aws_lambda_builders.builder import LambdaBuilder
 from aws_lambda_builders.exceptions import WorkflowFailedError
 
-import mock
 import logging
 
 logger = logging.getLogger("aws_lambda_builders.workflows.ruby_bundler.bundler")

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,7 +1,7 @@
 from pathlib import Path
-from typing import List, Tuple
 from unittest import TestCase
-from mock import patch, ANY, Mock
+from unittest.mock import ANY, patch
+
 from parameterized import parameterized
 
 from aws_lambda_builders.actions import (

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -1,7 +1,8 @@
 import itertools
 from unittest import TestCase
-from mock import patch, call, Mock
-from parameterized import parameterized, param
+from unittest.mock import patch, call, Mock
+
+from parameterized import parameterized
 
 from aws_lambda_builders.builder import LambdaBuilder
 from aws_lambda_builders.workflow import BuildDirectory, BuildInSourceSupport, Capability, BaseWorkflow

--- a/tests/unit/test_path_resolver.py
+++ b/tests/unit/test_path_resolver.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
+from unittest.mock import patch
+
 import os
-import mock
 
 from aws_lambda_builders import utils
 from aws_lambda_builders.path_resolver import PathResolver
@@ -22,6 +23,6 @@ class TestPathResolver(TestCase):
             self.path_resolver._which()
 
     def test_which_success_immediate(self):
-        with mock.patch.object(self.path_resolver, "_which") as which_mock:
+        with patch.object(self.path_resolver, "_which") as which_mock:
             which_mock.return_value = os.getcwd()
             self.assertEqual(self.path_resolver.exec_paths, os.getcwd())

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
-from mock import Mock, call
+from unittest.mock import Mock, call
+
 from parameterized import parameterized
 
 from aws_lambda_builders.registry import Registry, DEFAULT_REGISTRY, get_workflow

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,14 +1,11 @@
 import os
 import sys
 from unittest import TestCase
+from unittest.mock import Mock, MagicMock, call
+
 from parameterized import parameterized
 
-from mock import Mock, MagicMock, call
-
-try:
-    import pathlib
-except ImportError:
-    import pathlib2 as pathlib
+import pathlib
 
 from aws_lambda_builders.binary_path import BinaryPath
 from aws_lambda_builders.validator import RuntimeValidator

--- a/tests/unit/workflows/custom_make/test_actions.py
+++ b/tests/unit/workflows/custom_make/test_actions.py
@@ -1,8 +1,7 @@
 import os
 
 from unittest import TestCase
-
-from mock import patch, ANY
+from unittest.mock import patch, ANY
 
 from aws_lambda_builders.actions import ActionFailedError
 from aws_lambda_builders.workflows.custom_make.utils import OSUtils

--- a/tests/unit/workflows/custom_make/test_make.py
+++ b/tests/unit/workflows/custom_make/test_make.py
@@ -1,6 +1,6 @@
 import io
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.workflows.custom_make.make import MakeExecutionError, SubProcessMake
 

--- a/tests/unit/workflows/custom_make/test_workflow.py
+++ b/tests/unit/workflows/custom_make/test_workflow.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
-from unittest.mock import patch
 
-from aws_lambda_builders.architecture import X86_64, ARM64
+from aws_lambda_builders.architecture import ARM64
 from aws_lambda_builders.actions import CopySourceAction
 from aws_lambda_builders.exceptions import WorkflowFailedError
 from aws_lambda_builders.workflows.custom_make.workflow import CustomMakeWorkflow

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import os
 import platform
 from concurrent.futures import ThreadPoolExecutor
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.actions import ActionFailedError
 from aws_lambda_builders.architecture import ARM64, X86_64

--- a/tests/unit/workflows/dotnet_clipackage/test_dotnetcli.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_dotnetcli.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from aws_lambda_builders.workflows.dotnet_clipackage.dotnetcli import SubprocessDotnetCLI, DotnetCLIExecutionError
 

--- a/tests/unit/workflows/dotnet_clipackage/test_dotnetcli_resolver.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_dotnetcli_resolver.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.workflows.dotnet_clipackage.dotnetcli_resolver import DotnetCliResolver
 

--- a/tests/unit/workflows/dotnet_clipackage/test_workflow.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_workflow.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from aws_lambda_builders.architecture import ARM64, X86_64
+from aws_lambda_builders.architecture import ARM64
 from aws_lambda_builders.workflows.dotnet_clipackage.workflow import DotnetCliPackageWorkflow
 from aws_lambda_builders.workflows.dotnet_clipackage.actions import GlobalToolInstallAction, RunPackageAction
 

--- a/tests/unit/workflows/go_modules/test_actions.py
+++ b/tests/unit/workflows/go_modules/test_actions.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.actions import ActionFailedError
 from aws_lambda_builders.workflows.go_modules.actions import GoModulesBuildAction

--- a/tests/unit/workflows/go_modules/test_builder.py
+++ b/tests/unit/workflows/go_modules/test_builder.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from pathlib import Path
 
 from aws_lambda_builders.binary_path import BinaryPath

--- a/tests/unit/workflows/go_modules/test_validator.py
+++ b/tests/unit/workflows/go_modules/test_validator.py
@@ -1,6 +1,5 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
-import mock
 from parameterized import parameterized
 
 from aws_lambda_builders.exceptions import MisMatchRuntimeError

--- a/tests/unit/workflows/java/test_actions.py
+++ b/tests/unit/workflows/java/test_actions.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 import os
 
 from aws_lambda_builders.actions import ActionFailedError

--- a/tests/unit/workflows/java_gradle/test_actions.py
+++ b/tests/unit/workflows/java_gradle/test_actions.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch, call
+from unittest.mock import patch, call
 import os
 
 from aws_lambda_builders.actions import ActionFailedError

--- a/tests/unit/workflows/java_gradle/test_gradle.py
+++ b/tests/unit/workflows/java_gradle/test_gradle.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.binary_path import BinaryPath
 from aws_lambda_builders.workflows.java_gradle.gradle import (

--- a/tests/unit/workflows/java_gradle/test_gradle_validator.py
+++ b/tests/unit/workflows/java_gradle/test_gradle_validator.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from parameterized import parameterized
 from aws_lambda_builders.workflows.java_gradle.gradle_validator import GradleValidator
 from aws_lambda_builders.exceptions import UnsupportedRuntimeError, UnsupportedArchitectureError

--- a/tests/unit/workflows/java_gradle/test_gradlew_resolver.py
+++ b/tests/unit/workflows/java_gradle/test_gradlew_resolver.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch
+from unittest.mock import patch
 from parameterized import parameterized
 from aws_lambda_builders.workflows.java_gradle.gradle_resolver import GradleResolver
 

--- a/tests/unit/workflows/java_maven/test_actions.py
+++ b/tests/unit/workflows/java_maven/test_actions.py
@@ -1,6 +1,5 @@
-import shutil
 from unittest import TestCase
-from mock import patch, call, ANY
+from unittest.mock import patch, call, ANY
 import os
 
 from aws_lambda_builders.actions import ActionFailedError

--- a/tests/unit/workflows/java_maven/test_maven.py
+++ b/tests/unit/workflows/java_maven/test_maven.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.binary_path import BinaryPath
 from aws_lambda_builders.workflows.java_maven.maven import SubprocessMaven, MavenExecutionError

--- a/tests/unit/workflows/java_maven/test_maven_resolver.py
+++ b/tests/unit/workflows/java_maven/test_maven_resolver.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch
+from unittest.mock import patch
 from aws_lambda_builders.workflows.java_maven.maven_resolver import MavenResolver
 
 

--- a/tests/unit/workflows/java_maven/test_maven_validator.py
+++ b/tests/unit/workflows/java_maven/test_maven_validator.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from parameterized import parameterized
 from aws_lambda_builders.workflows.java_maven.maven_validator import MavenValidator
 from aws_lambda_builders.exceptions import UnsupportedRuntimeError, UnsupportedArchitectureError

--- a/tests/unit/workflows/java_maven/test_workflow.py
+++ b/tests/unit/workflows/java_maven/test_workflow.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch, ANY
+from unittest.mock import patch, ANY
 
 from aws_lambda_builders.workflows.java.actions import JavaCopyDependenciesAction, JavaMoveDependenciesAction
 from aws_lambda_builders.workflows.java_maven.workflow import JavaMavenWorkflow

--- a/tests/unit/workflows/nodejs_npm/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm/test_actions.py
@@ -1,6 +1,6 @@
 import itertools
 from unittest import TestCase
-from mock import patch, call
+from unittest.mock import patch, call
 from parameterized import parameterized
 
 from aws_lambda_builders.actions import ActionFailedError

--- a/tests/unit/workflows/nodejs_npm/test_npm.py
+++ b/tests/unit/workflows/nodejs_npm/test_npm.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.workflows.nodejs_npm.npm import SubprocessNpm, NpmExecutionError
 

--- a/tests/unit/workflows/nodejs_npm/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm/test_workflow.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch, call
+from unittest.mock import patch, call
 
 from aws_lambda_builders.actions import CopySourceAction, CleanUpAction, CopyDependenciesAction, MoveDependenciesAction
 from aws_lambda_builders.architecture import ARM64

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_actions.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from mock import patch
 from parameterized import parameterized
 
 from aws_lambda_builders.actions import ActionFailedError

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 from parameterized import parameterized
 
 from aws_lambda_builders.actions import ActionFailedError

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
@@ -314,9 +314,10 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             source_dir="source", install_dir="scratch_dir", subprocess_npm=ANY, osutils=ANY, build_options=None
         )
 
+    @patch("aws_lambda_builders.workflows.nodejs_npm_esbuild.workflow.NodejsNpmEsbuildWorkflow._get_esbuild_subprocess")
     @patch("aws_lambda_builders.workflows.nodejs_npm_esbuild.workflow.SubprocessNpm")
     @patch("aws_lambda_builders.workflows.nodejs_npm_esbuild.workflow.OSUtils")
-    def test_manifest_not_found(self, osutils_mock, subprocess_npm_mock):
+    def test_manifest_not_found(self, osutils_mock, subprocess_npm_mock, get_esbuild_subprocess_mock):
         osutils_mock.file_exists.return_value = False
 
         workflow = NodejsNpmEsbuildWorkflow(

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from unittest import TestCase
-from unittest.mock import ANY
-
-from mock import patch, call
+from unittest.mock import ANY, patch, call
 
 from aws_lambda_builders.actions import (
     CopySourceAction,

--- a/tests/unit/workflows/python_pip/test_actions.py
+++ b/tests/unit/workflows/python_pip/test_actions.py
@@ -1,7 +1,7 @@
 import sys
 
 from unittest import TestCase
-from mock import patch, Mock, ANY
+from unittest.mock import patch, Mock, ANY
 
 from aws_lambda_builders.actions import ActionFailedError
 from aws_lambda_builders.architecture import ARM64, X86_64

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -1,8 +1,7 @@
 import sys
 from collections import namedtuple
-from unittest import TestCase
+from unittest import TestCase, mock
 
-import mock
 import pytest
 
 from aws_lambda_builders.architecture import ARM64, X86_64

--- a/tests/unit/workflows/python_pip/test_validator.py
+++ b/tests/unit/workflows/python_pip/test_validator.py
@@ -1,6 +1,5 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
-import mock
 from parameterized import parameterized
 
 from aws_lambda_builders.exceptions import MisMatchRuntimeError

--- a/tests/unit/workflows/python_pip/test_workflow.py
+++ b/tests/unit/workflows/python_pip/test_workflow.py
@@ -1,6 +1,5 @@
-import mock
-from mock import patch, ANY, Mock
 from unittest import TestCase
+from unittest.mock import patch, ANY, Mock
 
 from parameterized import parameterized_class
 
@@ -139,7 +138,7 @@ class TestPythonPipWorkflow(TestCase):
         self.assertIsInstance(self.workflow.actions[0], CopySourceAction)
 
     def test_workflow_sets_up_actions_without_combine_dependencies(self):
-        osutils_mock = mock.Mock(spec=self.osutils)
+        osutils_mock = Mock(spec=self.osutils)
         osutils_mock.file_exists.return_value = True
         self.workflow = PythonPipWorkflow(
             "source",

--- a/tests/unit/workflows/ruby_bundler/test_actions.py
+++ b/tests/unit/workflows/ruby_bundler/test_actions.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.actions import ActionFailedError
 from aws_lambda_builders.workflows.ruby_bundler.actions import RubyBundlerInstallAction, RubyBundlerVendorAction

--- a/tests/unit/workflows/ruby_bundler/test_bundler.py
+++ b/tests/unit/workflows/ruby_bundler/test_bundler.py
@@ -1,9 +1,8 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from aws_lambda_builders.workflows.ruby_bundler.bundler import SubprocessBundler, BundlerExecutionError
 
-import mock
 import logging
 
 logger = logging.getLogger("aws_lambda_builders.workflows.ruby_bundler.bundler")
@@ -63,7 +62,7 @@ class TestSubprocessBundler(TestCase):
 
     def test_logs_warning_when_gemfile_missing(self):
         self.popen.returncode = 10
-        with mock.patch.object(logger, "warning") as mock_warning:
+        with patch.object(logger, "warning") as mock_warning:
             self.under_test.run(["install", "--without", "development", "test"])
         mock_warning.assert_called_once_with("Gemfile not found. Continuing the build without dependencies.")
 

--- a/tests/unit/workflows/ruby_bundler/test_workflow.py
+++ b/tests/unit/workflows/ruby_bundler/test_workflow.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from aws_lambda_builders.actions import CopySourceAction, CopyDependenciesAction, CleanUpAction
-from aws_lambda_builders.architecture import X86_64, ARM64
+from aws_lambda_builders.architecture import ARM64
 from aws_lambda_builders.workflows.ruby_bundler.workflow import RubyBundlerWorkflow
 from aws_lambda_builders.workflows.ruby_bundler.actions import RubyBundlerInstallAction, RubyBundlerVendorAction
 

--- a/tests/unit/workflows/rust_cargo/test_actions.py
+++ b/tests/unit/workflows/rust_cargo/test_actions.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 import io
 import logging
 import os


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Replaces https://github.com/aws/aws-lambda-builders/pull/447 as there isn't a need to depend on the 3rd party mock as it is no in the stdlib of python as of py3.3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
