### PR TITLE
chore: Enable workflow to trigger on merge_group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - develop
+  merge_group:
+    types: [checks_requested]
+    branches: 
+      - develop
 
 jobs:
   run-workflow:


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
From Github docs, Workflows need to be trigger-able by the merge queue. I think this was why the merge queue was not working as expected. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
