### PR TITLE
fix: Enable --manifest flag for esbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,6 @@ black-check:
 
 # Verifications to run before sending a pull request
 pr: init dev black-check
+
+format: black
+	ruff aws_lambda_builders --fix

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -172,6 +172,8 @@ class NodejsNpmWorkflow(BaseWorkflow):
         osutils: OSUtils,
         build_options: Optional[dict],
         install_links: Optional[bool] = False,
+        manifest_path: Optional[str] = None,
+        specify_manifest: Optional[bool] = False,
     ):
         """
         Get the install action used to install dependencies.
@@ -190,6 +192,8 @@ class NodejsNpmWorkflow(BaseWorkflow):
             Object containing build options configurations
         install_links : Optional[bool]
             Uses the --install-links npm option if True, by default False
+        manifest_path: Optional[str]
+            Path to the manifest file
 
         Returns
         -------
@@ -209,5 +213,9 @@ class NodejsNpmWorkflow(BaseWorkflow):
             )
 
         return NodejsNpmInstallAction(
-            install_dir=install_dir, subprocess_npm=subprocess_npm, install_links=install_links
+            install_dir=install_dir,
+            subprocess_npm=subprocess_npm,
+            install_links=install_links,
+            manifest_path=manifest_path,
+            specify_manifest=specify_manifest,
         )

--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
@@ -5,8 +5,10 @@ NodeJS NPM Workflow using the esbuild bundler
 import json
 import logging
 from pathlib import Path
+from typing import List
 
 from aws_lambda_builders.actions import (
+    BaseAction,
     CleanUpAction,
     CopySourceAction,
     LinkSourceAction,
@@ -78,13 +80,15 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
             )
 
         # if we're building in the source directory, we don't have to copy the source code
-        self.actions = (
+        self.actions: List[BaseAction] = (
             []
             if self.build_dir == self.source_dir
             else [CopySourceAction(source_dir=self.source_dir, dest_dir=self.build_dir, excludes=self.EXCLUDED_FILES)]
         )
 
         if self.download_dependencies:
+            # Manifest is different from the one in the project directory
+            specify_manifest = str(Path(manifest_path).parent) != source_dir
             self.actions.append(
                 NodejsNpmWorkflow.get_install_action(
                     source_dir=source_dir,
@@ -93,6 +97,8 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
                     osutils=self.osutils,
                     build_options=self.options,
                     install_links=self.build_dir == self.source_dir,
+                    manifest_path=self.manifest_path,
+                    specify_manifest=specify_manifest,
                 )
             )
 

--- a/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
+++ b/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
@@ -491,3 +491,24 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         expected_files = {"included.js"}
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
+
+    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    def test_esbuild_manifest_separate_directory(self, runtime):
+        source_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-manifest-outside-root")
+
+        options = {"entry_points": ["included.js"]}
+
+        self.builder.build(
+            source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            os.path.join(source_dir, "package_dir", "package.json"),
+            runtime=runtime,
+            options=options,
+            experimental_flags=[],
+            executable_search_paths=[self.binpath],
+        )
+
+        expected_files = {"included.js"}
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)

--- a/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/included.js
+++ b/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/included.js
@@ -1,0 +1,6 @@
+//included
+const request = require('minimal-request-promise');
+exports.handler = async (event, context) => {
+	const result = await(request.get(event.url));
+	return request;
+};

--- a/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/package_dir/package-lock.json
+++ b/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/package_dir/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "with-deps-esbuild",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "with-deps-esbuild",
+      "version": "1.0.0",
+      "license": "APACHE2.0",
+      "dependencies": {
+        "minimal-request-promise": "^1.5.0"
+      },
+      "devDependencies": {
+        "esbuild": "^0.11.23"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
+      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      }
+    },
+    "node_modules/minimal-request-promise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/minimal-request-promise/-/minimal-request-promise-1.5.0.tgz",
+      "integrity": "sha1-YPXX9VtAJtGXB04uFVYm1MxcLrw="
+    }
+  },
+  "dependencies": {
+    "esbuild": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
+      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
+      "dev": true
+    },
+    "minimal-request-promise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/minimal-request-promise/-/minimal-request-promise-1.5.0.tgz",
+      "integrity": "sha1-YPXX9VtAJtGXB04uFVYm1MxcLrw="
+    }
+  }
+}

--- a/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/package_dir/package.json
+++ b/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/package_dir/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "with-deps-esbuild",
+  "version": "1.0.0",
+  "description": "",
+  "keywords": [],
+  "author": "",
+  "license": "APACHE2.0",
+  "dependencies": {
+    "minimal-request-promise": "^1.5.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.11.23"
+  }
+}

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
@@ -310,6 +310,8 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             osutils=ANY,
             build_options=None,
             install_links=False,
+            manifest_path="manifest",
+            specify_manifest=True,
         )
 
     @patch("aws_lambda_builders.workflows.nodejs_npm_esbuild.workflow.NodejsNpmEsbuildWorkflow._get_esbuild_subprocess")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/4832

*Description of changes:*
Pass through the manifest path explicitly if it differs from the one in the code URI root directory. This allows the `--manifest` flag passed down to be different from the one in the root.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
