### PR TITLE
Add compatibility with setuptools 66+

### DIFF
--- a/tests/functional/workflows/python_pip/test_packager.py
+++ b/tests/functional/workflows/python_pip/test_packager.py
@@ -902,14 +902,14 @@ class TestSdistMetadataFetcher(object):
         # The whole reason we need to use the egg info to get the name and
         # version is that we cannot deterministically parse that information
         # from the filenames themselves. This test puts hyphens in the name
-        # and version which would break a simple ``split("-")`` attempt to get
-        # that information.
-        setup_py = self._SETUP_PY % (self._SETUPTOOLS, "foo-bar", "1.0-2b")
+        # which would break a simple ``split("-")`` attempt to get that
+        # information.
+        setup_py = self._SETUP_PY % (self._SETUPTOOLS, "foo-bar", "1.2b2")
         with osutils.tempdir() as tempdir:
             filepath = self._write_fake_sdist(setup_py, tempdir, "tar.gz")
             name, version = sdist_reader.get_package_name_and_version(filepath)
         assert name == "foo-bar"
-        assert version == "1.0-2b"
+        assert version == "1.2b2"
 
     def test_setup_zip(self, osutils, sdist_reader):
         setup_py = self._SETUP_PY % (self._SETUPTOOLS, "foo", "1.0")
@@ -944,20 +944,20 @@ class TestSdistMetadataFetcher(object):
         assert version == "1.0"
 
     def test_both_tar_gz(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (self._BOTH, "foo-bar", "1.0-2b")
+        setup_py = self._SETUP_PY % (self._BOTH, "foo-bar", "1.0b2")
         with osutils.tempdir() as tempdir:
             filepath = self._write_fake_sdist(setup_py, tempdir, "tar.gz")
             name, version = sdist_reader.get_package_name_and_version(filepath)
         assert name == "foo-bar"
-        assert version == "1.0-2b"
+        assert version == "1.0b2"
 
     def test_both_tar_bz2(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (self._BOTH, "foo-bar", "1.0-2b")
+        setup_py = self._SETUP_PY % (self._BOTH, "foo-bar", "1.0b2")
         with osutils.tempdir() as tempdir:
             filepath = self._write_fake_sdist(setup_py, tempdir, "tar.bz2")
             name, version = sdist_reader.get_package_name_and_version(filepath)
         assert name == "foo-bar"
-        assert version == "1.0-2b"
+        assert version == "1.0b2"
 
     def test_both_zip(self, osutils, sdist_reader):
         setup_py = self._SETUP_PY % (self._BOTH, "foo", "1.0")


### PR DESCRIPTION
This fixes https://github.com/aws/aws-lambda-builders/issues/474

setuptools 66.0.0 dropped support for PEP 440 non-conforming versions. A few of the unittests in this repo use versions that are not PEP 440 compatible. I changed them to be compatible, and now those tests pass =)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
