### PR TITLE
fix: Updated regex to match newer pip output

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -661,7 +661,11 @@ class PipRunner(object):
     # Update regex pattern to correspond with the updated output from pip
     # Specific commit:
     # https://github.com/pypa/pip/commit/b28e2c4928cc62d90b738a4613886fb1e2ad6a81#diff-5225c8e359020adb25dfc8c7a505950fd649c6c5775789c6f6517f7913f94542L529
-    _LINK_IS_DIR_PATTERNS = ["Processing (.+?)\n"]
+    #
+    # Commit that adds extra info to the end:
+    # https://github.com/pypa/pip/commit/c546c99480875cfe4cdeaefa6d16bad9998d0f70#diff-5225c8e359020adb25dfc8c7a505950fd649c6c5775789c6f6517f7913f94542R275-R281
+    # eg. Processing ./package_a (from 123==1.1.1->-r requirements.txt (line 1))
+    _LINK_IS_DIR_PATTERNS = ["Processing (.+?)[ ,\n]"]
 
     def __init__(self, python_exe, pip, osutils=None):
         if osutils is None:

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -270,6 +270,13 @@ class TestPipRunner(object):
         assert len(pip.calls) == 2
         assert pip.calls[1].args == ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-dir"]
 
+    def test_does_find_local_nested_directory(self, pip_factory):
+        pip, runner = pip_factory()
+        pip.add_return((0, b"Processing ../local-nested-dir (from xyz==123 and other info here)\n", b""))
+        runner.download_all_dependencies("requirements.txt", "directory")
+        assert len(pip.calls) == 2
+        assert pip.calls[1].args == ["wheel", "--no-deps", "--wheel-dir", "directory", "../local-nested-dir"]
+
     def test_does_find_multiple_local_directories(self, pip_factory):
         pip, runner = pip_factory()
         pip.add_return(


### PR DESCRIPTION
*Issue #, if available:*
#489 

*Description of changes:*
Newer versions of `pip` updated the output of `pip download`, causing our local package logic to fail.

`pip 23.0`
```
...
Processing ./package_a
...
```

`pip 23.1`
```
...
Processing ./package_a (from 123==1.1.1->-r requirements.txt (line 1))
...
```

This change updates the regex to stop at a space, or a newline, which ever appears first.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
