### PR TITLE
Add function architecture argument when building dotnet function 

### DIFF
--- a/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
@@ -7,7 +7,7 @@ import os
 import threading
 
 from aws_lambda_builders.actions import ActionFailedError, BaseAction, Purpose
-from aws_lambda_builders.architecture import ARM64
+from aws_lambda_builders.architecture import ARM64, X86_64
 from aws_lambda_builders.workflow import BuildMode
 
 from .dotnetcli import DotnetCLIExecutionError
@@ -62,13 +62,35 @@ class GlobalToolInstallAction(BaseAction):
 class RunPackageAction(BaseAction):
     """
     A Lambda Builder Action which builds the .NET Core project using the Amazon.Lambda.Tools .NET Core Global Tool
+
+    :param source_dir: str
+        Path to a folder containing the source code
+
+    :param subprocess_dotnet:
+        An instance of the dotnet process wrapper
+
+    :param artifacts_dir: str
+        Path to a folder where the built artifacts should be placed
+
+    :param options:
+        Dictionary of options ot pass to build action
+
+    :param mode: str
+        Mode the build should produce
+
+    :param architecture: str
+        Architecture to build for. Default value is X86_64 which is consistent with Amazon Lambda Tools
+
+    :param os_utils:
+        Optional, OS utils
+
     """
 
     NAME = "RunPackageAction"
     DESCRIPTION = "Execute the `dotnet lambda package` command."
     PURPOSE = Purpose.COMPILE_SOURCE
 
-    def __init__(self, source_dir, subprocess_dotnet, artifacts_dir, options, mode, architecture=None, os_utils=None):
+    def __init__(self, source_dir, subprocess_dotnet, artifacts_dir, options, mode, architecture=X86_64, os_utils=None):
         super(RunPackageAction, self).__init__()
         self.source_dir = source_dir
         self.subprocess_dotnet = subprocess_dotnet
@@ -90,9 +112,9 @@ class RunPackageAction(BaseAction):
                 "package",
                 "--output-package",
                 zipfullpath,
-                # Specify the architecture with the --runtime MSBuild parameter
-                "--msbuild-parameters",
-                "--runtime " + self._get_runtime(),
+                # pass function architecture to Amazon Lambda Tools.
+                "--function-architecture",
+                self.architecture,
             ]
 
             if self.mode and self.mode.lower() == BuildMode.DEBUG:

--- a/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
@@ -7,7 +7,7 @@ import os
 import threading
 
 from aws_lambda_builders.actions import ActionFailedError, BaseAction, Purpose
-from aws_lambda_builders.architecture import ARM64
+from aws_lambda_builders.architecture import ARM64, X86_64
 from aws_lambda_builders.workflow import BuildMode
 
 from .dotnetcli import DotnetCLIExecutionError
@@ -62,13 +62,35 @@ class GlobalToolInstallAction(BaseAction):
 class RunPackageAction(BaseAction):
     """
     A Lambda Builder Action which builds the .NET Core project using the Amazon.Lambda.Tools .NET Core Global Tool
+
+    :param source_dir: str
+        Path to a folder containing the source code
+
+    :param subprocess_dotnet:
+        An instance of the dotnet process wrapper
+
+    :param artifacts_dir: str
+        Path to a folder where the built artifacts should be placed
+
+    :param options:
+        Dictionary of options ot pass to build action
+
+    :param mode: str
+        Mode the build should produce
+
+    :param architecture: str
+        Architecture to build for. Default value is X86_64 which is consistent with Amazon Lambda Tools
+
+    :param os_utils:
+        Optional, OS utils
+
     """
 
     NAME = "RunPackageAction"
     DESCRIPTION = "Execute the `dotnet lambda package` command."
     PURPOSE = Purpose.COMPILE_SOURCE
 
-    def __init__(self, source_dir, subprocess_dotnet, artifacts_dir, options, mode, architecture=None, os_utils=None):
+    def __init__(self, source_dir, subprocess_dotnet, artifacts_dir, options, mode, architecture=X86_64, os_utils=None):
         super(RunPackageAction, self).__init__()
         self.source_dir = source_dir
         self.subprocess_dotnet = subprocess_dotnet
@@ -90,6 +112,9 @@ class RunPackageAction(BaseAction):
                 "package",
                 "--output-package",
                 zipfullpath,
+                # Pass function architecture to Amazon Lambda Tools.
+                "--function-architecture",
+                self.architecture,
                 # Specify the architecture with the --runtime MSBuild parameter
                 "--msbuild-parameters",
                 "--runtime " + self._get_runtime(),

--- a/tests/integration/workflows/dotnet_clipackage/testdata/CustomRuntime6/aws-lambda-tools-defaults.json
+++ b/tests/integration/workflows/dotnet_clipackage/testdata/CustomRuntime6/aws-lambda-tools-defaults.json
@@ -12,5 +12,5 @@
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "bootstrap",
-  "msbuild-parameters": "--self-contained true"
+  "msbuild-parameters": "--self-contained false"
 }

--- a/tests/integration/workflows/dotnet_clipackage/testdata/CustomRuntime6/aws-lambda-tools-defaults.json
+++ b/tests/integration/workflows/dotnet_clipackage/testdata/CustomRuntime6/aws-lambda-tools-defaults.json
@@ -12,5 +12,5 @@
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "bootstrap",
-  "msbuild-parameters": "--self-contained false"
+  "msbuild-parameters": "--self-contained true"
 }

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -89,7 +89,7 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-x64"],
+            ["lambda", "package", "--output-package", zip_path, "--function-architecture", X86_64],
             cwd="/source_dir",
         )
 
@@ -106,7 +106,7 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-x64"],
+            ["lambda", "package", "--output-package", zip_path, "--function-architecture", X86_64],
             cwd="/source_dir",
         )
 
@@ -123,7 +123,7 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-arm64"],
+            ["lambda", "package", "--output-package", zip_path, "--function-architecture", ARM64],
             cwd="/source_dir",
         )
 
@@ -144,8 +144,8 @@ class TestRunPackageAction(TestCase):
                 "package",
                 "--output-package",
                 zip_path,
-                "--msbuild-parameters",
-                "--runtime linux-x64",
+                "--function-architecture",
+                X86_64,
                 "--framework",
                 "netcoreapp2.1",
             ],
@@ -180,8 +180,8 @@ class TestRunPackageAction(TestCase):
                 "package",
                 "--output-package",
                 zip_path,
-                "--msbuild-parameters",
-                "--runtime linux-x64",
+                "--function-architecture",
+                X86_64,
                 "--configuration",
                 "Debug",
             ],

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -89,7 +89,7 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--function-architecture", X86_64],
+            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-x64"],
             cwd="/source_dir",
         )
 
@@ -106,7 +106,7 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--function-architecture", X86_64],
+            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-x64"],
             cwd="/source_dir",
         )
 
@@ -123,7 +123,7 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--function-architecture", ARM64],
+            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-arm64"],
             cwd="/source_dir",
         )
 
@@ -144,8 +144,8 @@ class TestRunPackageAction(TestCase):
                 "package",
                 "--output-package",
                 zip_path,
-                "--function-architecture",
-                X86_64,
+                "--msbuild-parameters",
+                "--runtime linux-x64",
                 "--framework",
                 "netcoreapp2.1",
             ],
@@ -180,8 +180,8 @@ class TestRunPackageAction(TestCase):
                 "package",
                 "--output-package",
                 zip_path,
-                "--function-architecture",
-                X86_64,
+                "--msbuild-parameters",
+                "--runtime linux-x64",
                 "--configuration",
                 "Debug",
             ],

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -89,7 +89,16 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-x64"],
+            [
+                "lambda",
+                "package",
+                "--output-package",
+                zip_path,
+                "--function-architecture",
+                X86_64,
+                "--msbuild-parameters",
+                "--runtime linux-x64",
+            ],
             cwd="/source_dir",
         )
 
@@ -106,7 +115,16 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-x64"],
+            [
+                "lambda",
+                "package",
+                "--output-package",
+                zip_path,
+                "--function-architecture",
+                X86_64,
+                "--msbuild-parameters",
+                "--runtime linux-x64",
+            ],
             cwd="/source_dir",
         )
 
@@ -123,7 +141,16 @@ class TestRunPackageAction(TestCase):
         zip_path = os.path.join(self.artifacts_dir, "source_dir.zip")
 
         self.subprocess_dotnet.run.assert_called_once_with(
-            ["lambda", "package", "--output-package", zip_path, "--msbuild-parameters", "--runtime linux-arm64"],
+            [
+                "lambda",
+                "package",
+                "--output-package",
+                zip_path,
+                "--function-architecture",
+                ARM64,
+                "--msbuild-parameters",
+                "--runtime linux-arm64",
+            ],
             cwd="/source_dir",
         )
 
@@ -144,6 +171,8 @@ class TestRunPackageAction(TestCase):
                 "package",
                 "--output-package",
                 zip_path,
+                "--function-architecture",
+                X86_64,
                 "--msbuild-parameters",
                 "--runtime linux-x64",
                 "--framework",
@@ -180,6 +209,8 @@ class TestRunPackageAction(TestCase):
                 "package",
                 "--output-package",
                 zip_path,
+                "--function-architecture",
+                X86_64,
                 "--msbuild-parameters",
                 "--runtime linux-x64",
                 "--configuration",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change made:
1. To complete support for building ARM64 dotnet7 functions https://github.com/aws/aws-sam-build-images/pull/81. Pass down directly the `Architecture` parameter defined in SAM template to Amazon Lambda Tools via `--function-architecture` argument. Previously when building dotnet7 functions, users  also need to make changes in `aws-lambda-tools-defaults.json` in their source code directories.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
