### PR TITLE
chore: version bump to 1.32.0

### DIFF
--- a/aws_lambda_builders/__init__.py
+++ b/aws_lambda_builders/__init__.py
@@ -4,5 +4,5 @@ AWS Lambda Builder Library
 
 # Changing version will trigger a new release!
 # Please make the version change as the last step of your development.
-__version__ = "1.31.0"
+__version__ = "1.32.0"
 RPC_PROTOCOL_VERSION = "0.3"


### PR DESCRIPTION
Bump Lambda builders version to 1.32.0 to prepare for the Ruby 3.2 release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
