### PR TITLE
fix: Ignore flags not relevant to esbuild

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/esbuild.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/esbuild.py
@@ -101,6 +101,10 @@ class SubprocessEsbuild(object):
 
 NON_CONFIGURABLE_VALUES = {"bundle", "platform", "outdir"}
 
+# Ignore the values below. These are options that Lambda Builders accepts for
+# Node.js related workflows, but are not relevant to esbuild itself.
+ESBUILD_IGNORE_VALUES = {"use_npm_ci"}
+
 
 class EsbuildCommandBuilder:
     ENTRY_POINTS = "entry_points"
@@ -142,7 +146,7 @@ class EsbuildCommandBuilder:
                     config_value,
                 )
                 continue
-            if config_key == "entry_points":
+            if config_key == "entry_points" or config_key in ESBUILD_IGNORE_VALUES:
                 # Entry points are a required parameter and are handled by the build_entry_points() method
                 continue
             configuration_type_callback = self._get_config_type_callback(config_value)

--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/esbuild.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/esbuild.py
@@ -103,7 +103,7 @@ NON_CONFIGURABLE_VALUES = {"bundle", "platform", "outdir"}
 
 # Ignore the values below. These are options that Lambda Builders accepts for
 # Node.js related workflows, but are not relevant to esbuild itself.
-ESBUILD_IGNORE_VALUES = {"use_npm_ci"}
+ESBUILD_IGNORE_VALUES = {"use_npm_ci", "entry_points"}
 
 
 class EsbuildCommandBuilder:
@@ -146,8 +146,7 @@ class EsbuildCommandBuilder:
                     config_value,
                 )
                 continue
-            if config_key == "entry_points" or config_key in ESBUILD_IGNORE_VALUES:
-                # Entry points are a required parameter and are handled by the build_entry_points() method
+            if config_key in ESBUILD_IGNORE_VALUES:
                 continue
             configuration_type_callback = self._get_config_type_callback(config_value)
             LOG.debug("Configuring the parameter '%s=%s'", config_key, config_value)

--- a/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
+++ b/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
@@ -491,3 +491,24 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         expected_files = {"included.js"}
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
+
+    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    def test_builds_javascript_project_ignoring_relevant_flags(self, runtime):
+        source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild")
+
+        options = {"entry_points": ["included.js"], "use_npm_ci": True}
+
+        self.builder.build(
+            source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            os.path.join(source_dir, "package.json"),
+            runtime=runtime,
+            options=options,
+            experimental_flags=[],
+            executable_search_paths=[self.binpath],
+        )
+
+        expected_files = {"included.js"}
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_actions.py
@@ -329,6 +329,30 @@ class TestEsbuildBundleAction(TestCase):
         with self.assertRaises(ActionFailedError):
             action.execute()
 
+    def test_packages_javascript_ignoring_non_relevant_flags(self):
+        action = EsbuildBundleAction(
+            "source",
+            "artifacts",
+            {"entry_points": ["x.js"], "use_npm_ci": True},
+            self.osutils,
+            self.subprocess_esbuild,
+            "package.json",
+        )
+        action.execute()
+
+        self.subprocess_esbuild.run.assert_called_with(
+            [
+                "x.js",
+                "--bundle",
+                "--platform=node",
+                "--outdir=artifacts",
+                "--target=es2020",
+                "--format=cjs",
+                "--minify",
+            ],
+            cwd="source",
+        )
+
 
 class TestEsbuildVersionChecker(TestCase):
     @parameterized.expand(["0.14.0", "0.0.0", "0.14.12"])


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-build-images/issues/90
https://github.com/aws/aws-sam-cli/issues/5236

*Description of changes:*
Since making the change to accept any flags for esbuild, there is an issue with esbuild trying to use flags that are not related to it. This changes forces the esbuild command builder to ignore those unrelated flags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
