### PR TITLE
fix: Enable --manifest flag for esbuild and npm build

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -135,7 +135,6 @@ class NodejsNpmWorkflow(BaseWorkflow):
             )
 
         self.actions += self._actions_for_cleanup
-        print(self.actions)
 
     @property
     def _actions_for_cleanup(self):

--- a/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root-with-local-dependency/manifest/package.json
+++ b/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root-with-local-dependency/manifest/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "manifest-outside-root",
+  "version": "1.0.0",
+  "description": "",
+  "files": [
+    "../src/included.js"
+  ],
+  "keywords": [],
+  "author": "",
+  "license": "APACHE2.0",
+  "dependencies": {
+    "axios": "*",
+    "local-dependency": "file:../../npm-deps"
+  }
+}

--- a/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root-with-local-dependency/src/excluded.js
+++ b/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root-with-local-dependency/src/excluded.js
@@ -1,0 +1,2 @@
+//excluded
+const x = 1;

--- a/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root-with-local-dependency/src/included.js
+++ b/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root-with-local-dependency/src/included.js
@@ -1,0 +1,2 @@
+//included
+const x = 1;

--- a/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root/manifest/package.json
+++ b/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root/manifest/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "manifest-outside-root",
+  "version": "1.0.0",
+  "description": "",
+  "files": [
+    "../src/included.js"
+  ],
+  "keywords": [],
+  "author": "",
+  "license": "APACHE2.0",
+  "dependencies": {
+    "minimal-request-promise": "*"
+  }
+}

--- a/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root/src/excluded.js
+++ b/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root/src/excluded.js
@@ -1,0 +1,2 @@
+//excluded
+const x = 1;

--- a/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root/src/included.js
+++ b/tests/integration/workflows/nodejs_npm/testdata/manifest-outside-root/src/included.js
@@ -1,0 +1,2 @@
+//included
+const x = 1;

--- a/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
+++ b/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
@@ -30,6 +30,11 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         self.osutils = OSUtils()
         self._set_esbuild_binary_path()
 
+        # use this so tests don't modify actual testdata, and we can parallelize
+        self.temp_dir = tempfile.mkdtemp()
+        self.temp_testdata_dir = os.path.join(self.temp_dir, "testdata")
+        shutil.copytree(self.TEST_DATA_FOLDER, self.temp_testdata_dir)
+
     def _set_esbuild_binary_path(self):
         npm = SubprocessNpm(self.osutils)
         esbuild_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-binary")
@@ -40,6 +45,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
     def tearDown(self):
         shutil.rmtree(self.artifacts_dir)
         shutil.rmtree(self.scratch_dir)
+        shutil.rmtree(self.temp_dir)
 
         # clean up dependencies that were installed in source dir
         source_dependencies = os.path.join(self.source_dir, "node_modules")
@@ -512,3 +518,120 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         expected_files = {"included.js"}
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
+
+    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    def test_builds_typescript_projects_with_external_manifest(self, runtime):
+        base_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-manifest-outside-root")
+        source_dir = os.path.join(base_dir, "src")
+
+        options = {"entry_points": ["included.ts"]}
+
+        self.builder.build(
+            source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            os.path.join(base_dir, "manifest", "package.json"),
+            runtime=runtime,
+            options=options,
+            experimental_flags=[],
+            executable_search_paths=[self.binpath],
+        )
+
+        expected_files = {"included.js"}
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)
+
+    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    def test_builds_typescript_projects_with_external_manifest_with_dependencies_dir_without_combine(self, runtime):
+        base_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-manifest-outside-root")
+        source_dir = os.path.join(base_dir, "src")
+
+        options = {"entry_points": ["included.ts"]}
+
+        self.builder.build(
+            source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            os.path.join(base_dir, "manifest", "package.json"),
+            runtime=runtime,
+            options=options,
+            experimental_flags=[],
+            executable_search_paths=[self.binpath],
+            dependencies_dir=self.dependencies_dir,
+            download_dependencies=True,
+            combine_dependencies=False,
+        )
+
+        expected_files = {"included.js"}
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)
+
+        expected_modules = "minimal-request-promise"
+        output_modules = set(os.listdir(os.path.join(self.dependencies_dir, "node_modules")))
+        self.assertIn(expected_modules, output_modules)
+
+    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    def test_builds_typescript_projects_with_external_manifest_with_dependencies_dir_with_combine(self, runtime):
+        base_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-manifest-outside-root")
+        source_dir = os.path.join(base_dir, "src")
+
+        options = {"entry_points": ["included.ts"]}
+
+        self.builder.build(
+            source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            os.path.join(base_dir, "manifest", "package.json"),
+            runtime=runtime,
+            options=options,
+            experimental_flags=[],
+            executable_search_paths=[self.binpath],
+            dependencies_dir=self.dependencies_dir,
+            download_dependencies=True,
+            combine_dependencies=True,
+        )
+
+        expected_files = {"included.js"}
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)
+
+        expected_modules = "minimal-request-promise"
+        output_modules = set(os.listdir(os.path.join(self.dependencies_dir, "node_modules")))
+        self.assertIn(expected_modules, output_modules)
+
+    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    def test_builds_typescript_projects_with_external_manifest_and_local_depends(self, runtime):
+        base_dir = os.path.join(self.temp_testdata_dir, "esbuild-manifest-outside-root-with-local-depends")
+        source_dir = os.path.join(base_dir, "src")
+
+        options = {"entry_points": ["included.ts"]}
+
+        self.builder.build(
+            source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            os.path.join(base_dir, "manifest", "package.json"),
+            runtime=runtime,
+            options=options,
+            experimental_flags=[],
+            executable_search_paths=[self.binpath],
+            build_in_source=True,
+        )
+
+        expected_files = {"included.js"}
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)
+
+        # dependencies installed in source folder
+        self.assertIn("node_modules", os.listdir(source_dir))
+        self.assertIn("node_modules", os.listdir(os.path.join(base_dir, "manifest")))
+
+        expected_modules = ["minimal-request-promise", "axios"]
+        output_modules = set(os.listdir(os.path.join(source_dir, "node_modules")))
+        self.assertTrue(all(expected_module in output_modules for expected_module in expected_modules))
+
+        output_modules = set(os.listdir(os.path.join(os.path.join(base_dir, "manifest"), "node_modules")))
+        self.assertTrue(all(expected_module in output_modules for expected_module in expected_modules))
+
+        # dependencies not in scratch
+        self.assertNotIn("node_modules", os.listdir(self.scratch_dir))

--- a/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root-with-local-depends/manifest/package.json
+++ b/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root-with-local-depends/manifest/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "with-deps-esbuild-typescript",
+  "version": "1.0.0",
+  "description": "",
+  "keywords": [],
+  "author": "",
+  "license": "APACHE2.0",
+  "dependencies": {
+    "@types/aws-lambda": "^8.10.76",
+    "axios": "*",
+    "local-dependency": "file:../../with-deps-esbuild"
+  },
+  "devDependencies": {
+    "esbuild": "^0.11.23"
+  }
+}

--- a/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root-with-local-depends/src/included.ts
+++ b/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root-with-local-depends/src/included.ts
@@ -1,0 +1,12 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import {axios} from "axios";
+import * as requestPromise from "request-promise";
+
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const queries = JSON.stringify(event.queryStringParameters);
+  return {
+    statusCode: 200,
+    body: "OK" 
+  }
+}

--- a/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/manifest/package.json
+++ b/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/manifest/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "with-deps-esbuild-typescript",
+  "version": "1.0.0",
+  "description": "",
+  "keywords": [],
+  "author": "",
+  "license": "APACHE2.0",
+  "dependencies": {
+    "@types/aws-lambda": "^8.10.76",
+    "minimal-request-promise": "^1.5.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.11.23"
+  }
+}

--- a/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/src/included.ts
+++ b/tests/integration/workflows/nodejs_npm_esbuild/testdata/esbuild-manifest-outside-root/src/included.ts
@@ -1,0 +1,10 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import * as requestPromise from 'request-promise';
+
+export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const queries = JSON.stringify(event.queryStringParameters);
+  return {
+    statusCode: 200,
+    body: "OK" 
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/4832, I also found that this issue exist in the NPM build.

*Description of changes:*
For NPM Build:
 - added an action to copy the source code files to artifact directory in case if the passed manifest is in a different directory, as the used NPM Pack Action does not copy the source code files.
 - Run the NPM Install Action to run on the manifest directory if it exist outside the source code, and building in source. This action will enable supporting local dependencies. Then link the `node_modules` from the manifest directory to the source code directory.

For ESBuild:
 - added an action to copy the manifest directory content to build directory in case if the passed manifest is in a different directory, and the customer is not building in source.
 - Run the NPM Install Action to run on the manifest directory if it exist outside the source code, and building in source. This action will enable supporting local dependencies. Then link the `node_modules` from the manifest directory to the source code directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
