### PR TITLE
chore: Version bump to 1.35.0

### DIFF
--- a/aws_lambda_builders/__init__.py
+++ b/aws_lambda_builders/__init__.py
@@ -4,5 +4,5 @@ AWS Lambda Builder Library
 
 # Changing version will trigger a new release!
 # Please make the version change as the last step of your development.
-__version__ = "1.34.0"
+__version__ = "1.35.0"
 RPC_PROTOCOL_VERSION = "0.3"


### PR DESCRIPTION
bump lambda builders version to 1.35.0 to prepare for the 1.35.0 release 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
