### PR TITLE
fix: Fix missing encoding when logging from Makefile

### DIFF
--- a/aws_lambda_builders/workflows/custom_make/make.py
+++ b/aws_lambda_builders/workflows/custom_make/make.py
@@ -3,7 +3,6 @@ Wrapper around calling make through a subprocess.
 """
 import io
 import logging
-import os
 import shutil
 import sys
 import threading
@@ -100,7 +99,7 @@ class SubProcessMake(object):
             #
             # stderr is used since stdout appears to be reserved
             # for command responses
-            sys.stderr.buffer.write(line.strip() + os.linesep.encode())
+            sys.stderr.buffer.write(line)
             sys.stderr.flush()
 
             # Gather total stdout

--- a/aws_lambda_builders/workflows/custom_make/make.py
+++ b/aws_lambda_builders/workflows/custom_make/make.py
@@ -4,6 +4,7 @@ Wrapper around calling make through a subprocess.
 import io
 import logging
 import shutil
+import sys
 import threading
 
 LOG = logging.getLogger(__name__)
@@ -92,9 +93,11 @@ class SubProcessMake(object):
 
         # Log every stdout line by iterating
         for line in p.stdout:
-            decoded_line = line.decode("utf-8").strip()
-            LOG.info(decoded_line)
+            sys.stderr.buffer.write(line)
+            sys.stderr.flush()
+
             # Gather total stdout
+            decoded_line = line.decode("utf-8").strip()
             stdout += decoded_line
 
         # Wait for the process to exit and stderr thread to end.

--- a/aws_lambda_builders/workflows/custom_make/make.py
+++ b/aws_lambda_builders/workflows/custom_make/make.py
@@ -3,6 +3,7 @@ Wrapper around calling make through a subprocess.
 """
 import io
 import logging
+import os
 import shutil
 import sys
 import threading
@@ -93,7 +94,13 @@ class SubProcessMake(object):
 
         # Log every stdout line by iterating
         for line in p.stdout:
-            sys.stderr.buffer.write(line)
+            # Writing to stderr instead of using LOG.info
+            # since the logger library does not include ANSI
+            # formatting characters in the output
+            #
+            # stderr is used since stdout appears to be reserved
+            # for command responses
+            sys.stderr.buffer.write(line.strip() + os.linesep.encode())
             sys.stderr.flush()
 
             # Gather total stdout


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Some of the output that may come from a Makefile (eg. Terraform output) can contain some colour and encoding information (eg. `b'\x1b[0m\x1b[1mInitializing provider plugins...\x1b[0m\n' `). This does not get logged properly in the terminal.

Changes are to use `sys.stderr.buffer.write()` to print these messages instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
