### PR TITLE
Support PEP 600 platform tags for arm64

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -193,6 +193,7 @@ class DependencyBuilder(object):
     _MANYLINUX_LEGACY_MAP = {
         "manylinux1_x86_64": "manylinux_2_5_x86_64",
         "manylinux2010_x86_64": "manylinux_2_12_x86_64",
+        "manylinux2014_aarch64": "manylinux_2_17_aarch64",
         "manylinux2014_x86_64": "manylinux_2_17_x86_64",
     }
 


### PR DESCRIPTION
*Issue #, if available:

https://github.com/aws/aws-sam-cli/issues/3747

*Description of changes:*

Hey team,

We encountered an issue building cross-platform for `arm64` outside of a container with `sam build`:

```
Build Failed
Error: PythonPipBuilder:ResolveDependencies - {grpcio==1.57.0(wheel)}
```

**grpcio** does indeed have a wheel available in PyPI at `..._manylinux_2_17_aarch64.whl`, but **aws-sam-cli** is currently only able to resolve the `manylinux_2_17` tags for `x86_64` wheels.

This PR adds the alias in [PEP 600](https://peps.python.org/pep-0600/#legacy-manylinux-tags) for `manylinux2014_aarch64 -> manylinux_2_17_aarch64`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
