### PR TITLE
fix: Update esbuild binary fetching logic to look inside of `build_dir`

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
@@ -178,7 +178,7 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
 
     def _get_esbuild_subprocess(self) -> SubprocessEsbuild:
         try:
-            npm_bin_path_root = self.subprocess_npm.run(["root"], cwd=self.scratch_dir)
+            npm_bin_path_root = self.subprocess_npm.run(["root"], cwd=self.build_dir)
             npm_bin_path = str(Path(npm_bin_path_root, ".bin"))
         except FileNotFoundError:
             raise EsbuildExecutionError(message="The esbuild workflow couldn't find npm installed on your system.")

--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
@@ -183,6 +183,14 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
         return [PathResolver(runtime=self.runtime, binary="npm")]
 
     def _get_esbuild_subprocess(self) -> SubprocessEsbuild:
+        """
+        Creates a subprocess object that is able to invoke the esbuild executable.
+
+        Returns
+        -------
+        SubprocessEsbuild
+            An esbuild specific subprocess object
+        """
         try:
             npm_bin_path_root = self.subprocess_npm.run(["root"], cwd=self.build_dir)
             npm_bin_path = str(Path(npm_bin_path_root, ".bin"))

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
@@ -380,10 +380,10 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
 
         self.assertIsInstance(workflow.actions[0], CopySourceAction)
         self.assertIsInstance(workflow.actions[1], CopySourceAction)
-        self.assertEquals(workflow.actions[1].source_dir, "not_source")
-        self.assertEquals(workflow.actions[1].dest_dir, "scratch_dir")
+        self.assertEqual(workflow.actions[1].source_dir, "not_source")
+        self.assertEqual(workflow.actions[1].dest_dir, "scratch_dir")
         self.assertIsInstance(workflow.actions[2], NodejsNpmInstallAction)
-        self.assertEquals(workflow.actions[2].install_dir, "scratch_dir")
+        self.assertEqual(workflow.actions[2].install_dir, "scratch_dir")
         self.assertIsInstance(workflow.actions[3], EsbuildBundleAction)
 
     @patch("aws_lambda_builders.workflows.nodejs_npm.workflow.NodejsNpmWorkflow.can_use_install_links")
@@ -406,10 +406,10 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
         self.assertEqual(len(workflow.actions), 3)
 
         self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
-        self.assertEquals(workflow.actions[0].install_dir, "not_source")
+        self.assertEqual(workflow.actions[0].install_dir, "not_source")
         self.assertIsInstance(workflow.actions[1], LinkSinglePathAction)
-        self.assertEquals(workflow.actions[1]._source, os.path.join("not_source", "node_modules"))
-        self.assertEquals(workflow.actions[1]._dest, os.path.join("source", "node_modules"))
+        self.assertEqual(workflow.actions[1]._source, os.path.join("not_source", "node_modules"))
+        self.assertEqual(workflow.actions[1]._dest, os.path.join("source", "node_modules"))
         self.assertIsInstance(workflow.actions[2], EsbuildBundleAction)
 
     @patch("aws_lambda_builders.workflows.nodejs_npm.workflow.NodejsNpmWorkflow.can_use_install_links")
@@ -450,8 +450,9 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
     )
     @patch("aws_lambda_builders.workflows.nodejs_npm.workflow.NodejsNpmWorkflow.can_use_install_links")
     @patch("aws_lambda_builders.workflows.nodejs_npm_esbuild.workflow.SubprocessNpm.run")
+    @patch("aws_lambda_builders.workflows.nodejs_npm_esbuild.workflow.Path")
     def test_finds_correct_esbuild_binary(
-        self, is_building_in_source, expected_dir, subprocess_run_mock, install_links_mock
+        self, is_building_in_source, expected_dir, path_mock, subprocess_run_mock, install_links_mock
     ):
         install_links_mock.return_value = True
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The workflow currently looks at the scratch directory to determine if esbuild is present or not. This is not the case for build in source however, as the Node modules are installed in the source directory, not the scratch directory.

This change updates the path to be `build_dir`, which is already set to the correct folder from earlier in the workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
