### PR TITLE
fix: Reference variable from loop instead of the one from the validator

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/actions.py
+++ b/aws_lambda_builders/workflows/python_pip/actions.py
@@ -103,8 +103,8 @@ class PythonPipBuildAction(BaseAction):
                 # during the init phase
 
                 # we can ignore these and let the action fail at the end
-                LOG.debug(f"Python runtime path '{valid_python_path}' does not match the workflow")
+                LOG.debug(f"Python runtime path '{python_path}' does not match the workflow")
             except MissingPipError:
-                LOG.debug(f"Python runtime path '{valid_python_path}' does not contain pip")
+                LOG.debug(f"Python runtime path '{python_path}' does not contain pip")
 
         raise ActionFailedError("Failed to find a Python runtime containing pip on the PATH.")


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
The recent change to update the Python path resolution to find the correct one if pip is required could reference a variable that has not yet been assigned.

This fix updates the two logs to use the path string from the loop instead of the one from the validator output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
