### PR TITLE
fix: streaming stderr from subprocess started by lambda-builders

### DIFF
--- a/aws_lambda_builders/workflows/ruby_bundler/bundler.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/bundler.py
@@ -3,6 +3,7 @@ Wrapper around calls to bundler through a subprocess.
 """
 
 import logging
+import os
 
 LOG = logging.getLogger(__name__)
 
@@ -65,13 +66,19 @@ class SubprocessBundler(object):
                 if self.osutils.directory_exists(check_dir):
                     self.osutils.remove_directory(check_dir)
             else:
-                # Bundler has relevant information in stdout, not stderr.
+                # Bundler can contain information in both stdout and stderr so we check and log both
+                err_str = err.decode("utf8").strip()
+                out_str = out.decode("utf8").strip()
                 if out and err:
-                    message_out = out.strip() + b"\n" + err
+                    message_out = f"{out_str}{os.linesep}{err_str}"
+                    LOG.debug(f"Bundler output: {out_str}")
+                    LOG.debug(f"Bundler error: {err_str}")
                 elif out:
-                    message_out = out
+                    message_out = out_str
+                    LOG.debug(f"Bundler output: {out_str}")
                 else:
-                    message_out = err
-                raise BundlerExecutionError(message=message_out.decode("utf8").strip())
+                    message_out = err_str
+                    LOG.debug(f"Bundler error: {err_str}")
+                raise BundlerExecutionError(message=message_out)
 
         return out.decode("utf8").strip()

--- a/aws_lambda_builders/workflows/ruby_bundler/bundler.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/bundler.py
@@ -3,7 +3,7 @@ Wrapper around calls to bundler through a subprocess.
 """
 
 import logging
-import os
+from os import linesep
 
 LOG = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class SubprocessBundler(object):
                 err_str = err.decode("utf8").strip()
                 out_str = out.decode("utf8").strip()
                 if out and err:
-                    message_out = f"{out_str}{os.linesep}{err_str}"
+                    message_out = f"{out_str}{linesep}{err_str}"
                     LOG.debug(f"Bundler output: {out_str}")
                     LOG.debug(f"Bundler error: {err_str}")
                 elif out:

--- a/aws_lambda_builders/workflows/ruby_bundler/bundler.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/bundler.py
@@ -69,11 +69,11 @@ class SubprocessBundler(object):
                 # Bundler can contain information in both stdout and stderr so we check and log both
                 err_str = err.decode("utf8").strip()
                 out_str = out.decode("utf8").strip()
-                if out and err:
+                if out_str and err_str:
                     message_out = f"{out_str}{linesep}{err_str}"
                     LOG.debug(f"Bundler output: {out_str}")
                     LOG.debug(f"Bundler error: {err_str}")
-                elif out:
+                elif out_str:
                     message_out = out_str
                     LOG.debug(f"Bundler output: {out_str}")
                 else:

--- a/aws_lambda_builders/workflows/ruby_bundler/bundler.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/bundler.py
@@ -54,7 +54,7 @@ class SubprocessBundler(object):
 
         p = self.osutils.popen(invoke_bundler, stdout=self.osutils.pipe, stderr=self.osutils.pipe, cwd=cwd)
 
-        out, _ = p.communicate()
+        out, err = p.communicate()
 
         if p.returncode != 0:
             if p.returncode == GEMFILE_NOT_FOUND:
@@ -66,6 +66,12 @@ class SubprocessBundler(object):
                     self.osutils.remove_directory(check_dir)
             else:
                 # Bundler has relevant information in stdout, not stderr.
-                raise BundlerExecutionError(message=out.decode("utf8").strip())
+                if out and err:
+                    message_out = out.strip() + b"\n" + err
+                elif out:
+                    message_out = out
+                else:
+                    message_out = err
+                raise BundlerExecutionError(message=message_out.decode("utf8").strip())
 
         return out.decode("utf8").strip()

--- a/tests/unit/workflows/ruby_bundler/test_bundler.py
+++ b/tests/unit/workflows/ruby_bundler/test_bundler.py
@@ -73,12 +73,31 @@ class TestSubprocessBundler(TestCase):
         self.osutils.get_bundle_dir.assert_called_once()
         self.osutils.remove_directory.assert_called_once()
 
-    def test_raises_BundlerExecutionError_with_err_text_if_retcode_is_not_0(self):
+    def test_raises_BundlerExecutionError_with_stdout_text_if_retcode_is_not_0(self):
         self.popen.returncode = 1
         self.popen.out = b"some error text\n\n"
+        self.popen.err = b""
         with self.assertRaises(BundlerExecutionError) as raised:
             self.under_test.run(["install", "--without", "development", "test"])
         self.assertEqual(raised.exception.args[0], "Bundler Failed: some error text")
+
+    def test_raises_BundlerExecutionError_with_stderr_text_if_retcode_is_not_0(self):
+        self.popen.returncode = 1
+        self.popen.err = b"some error text\n\n"
+        self.popen.out = b""
+        with self.assertRaises(BundlerExecutionError) as raised:
+            self.under_test.run(["install", "--without", "development", "test"])
+        self.assertEqual(raised.exception.args[0], "Bundler Failed: some error text")
+
+    def test_raises_BundlerExecutionError_with_both_stderr_and_stdout_text_if_retcode_is_not_0(self):
+        self.popen.returncode = 1
+        self.popen.err = b"some error text from stderr\n\n"
+        self.popen.out = b"some error text from stdout\n\n"
+        with self.assertRaises(BundlerExecutionError) as raised:
+            self.under_test.run(["install", "--without", "development", "test"])
+        self.assertEqual(
+            raised.exception.args[0], "Bundler Failed: some error text from stdout\nsome error text from stderr"
+        )
 
     def test_raises_ValueError_if_args_not_a_list(self):
         with self.assertRaises(ValueError) as raised:

--- a/tests/unit/workflows/ruby_bundler/test_bundler.py
+++ b/tests/unit/workflows/ruby_bundler/test_bundler.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch
+from os import linesep
 
 from aws_lambda_builders.workflows.ruby_bundler.bundler import SubprocessBundler, BundlerExecutionError
 
@@ -96,7 +97,7 @@ class TestSubprocessBundler(TestCase):
         with self.assertRaises(BundlerExecutionError) as raised:
             self.under_test.run(["install", "--without", "development", "test"])
         self.assertEqual(
-            raised.exception.args[0], "Bundler Failed: some error text from stdout\nsome error text from stderr"
+            raised.exception.args[0], f"Bundler Failed: some error text from stdout{linesep}some error text from stderr"
         )
 
     def test_raises_ValueError_if_args_not_a_list(self):


### PR DESCRIPTION
*Issue #, if available:*
 [#6068](https://github.com/aws/aws-sam-cli/issues/6068)
*Description of changes:*
the stderr output of the subprocess was being ignored and because of this if there was no information in stdout all that a user would see was that the bundler failed.

This fix has the bundler output the stderr from the subprocess if it fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
