### PR TITLE
fix: Symlinks to non-existent directories, symlinks re-creating

### DIFF
--- a/aws_lambda_builders/actions.py
+++ b/aws_lambda_builders/actions.py
@@ -160,7 +160,7 @@ class LinkSinglePathAction(BaseAction):
         destination_path = Path(self._dest)
         if not source_path.exists():
             # Source path doesn't exist, nothing to symlink
-            LOG.debug("Source path %s does not exist, skipping generating symlink")
+            LOG.debug("Source path %s does not exist, skipping generating symlink", source_path)
             return
         if not destination_path.exists():
             os.makedirs(destination_path.parent, exist_ok=True)

--- a/aws_lambda_builders/actions.py
+++ b/aws_lambda_builders/actions.py
@@ -160,6 +160,7 @@ class LinkSinglePathAction(BaseAction):
         destination_path = Path(self._dest)
         if not source_path.exists():
             # Source path doesn't exist, nothing to symlink
+            LOG.debug("Source path %s does not exist, skipping linking")
             return
         if not destination_path.exists():
             os.makedirs(destination_path.parent, exist_ok=True)

--- a/aws_lambda_builders/actions.py
+++ b/aws_lambda_builders/actions.py
@@ -156,7 +156,11 @@ class LinkSinglePathAction(BaseAction):
         self._dest = dest
 
     def execute(self):
+        source_path = Path(self._source)
         destination_path = Path(self._dest)
+        if not source_path.exists():
+            # Source path doesn't exist, nothing to symlink
+            return
         if not destination_path.exists():
             os.makedirs(destination_path.parent, exist_ok=True)
         utils.create_symlink_or_copy(str(self._source), str(destination_path))

--- a/aws_lambda_builders/actions.py
+++ b/aws_lambda_builders/actions.py
@@ -160,7 +160,7 @@ class LinkSinglePathAction(BaseAction):
         destination_path = Path(self._dest)
         if not source_path.exists():
             # Source path doesn't exist, nothing to symlink
-            LOG.debug("Source path %s does not exist, skipping linking")
+            LOG.debug("Source path %s does not exist, skipping generating symlink")
             return
         if not destination_path.exists():
             os.makedirs(destination_path.parent, exist_ok=True)

--- a/aws_lambda_builders/utils.py
+++ b/aws_lambda_builders/utils.py
@@ -200,6 +200,7 @@ def create_symlink_or_copy(source: str, destination: str) -> None:
     try:
         if Path(destination).exists() and Path(destination).is_symlink():
             # The symlink is already in place, don't try re-creating it
+            LOG.debug("Symlink between %s and %s already exists, skipping generating symlink", source, destination)
             return
         os.symlink(Path(source).absolute(), Path(destination).absolute())
     except OSError as ex:

--- a/aws_lambda_builders/utils.py
+++ b/aws_lambda_builders/utils.py
@@ -198,6 +198,9 @@ def create_symlink_or_copy(source: str, destination: str) -> None:
     """Tries to create symlink, if it fails it will copy source into destination"""
     LOG.debug("Creating symlink; source: %s, destination: %s", source, destination)
     try:
+        if Path(destination).exists() and Path(destination).is_symlink():
+            # The symlink is already in place, don't try re-creating it
+            return
         os.symlink(Path(source).absolute(), Path(destination).absolute())
     except OSError as ex:
         LOG.warning(

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -12,6 +12,7 @@ from aws_lambda_builders.actions import (
     MoveDependenciesAction,
     CleanUpAction,
     DependencyManager,
+    LinkSinglePathAction,
 )
 
 
@@ -262,3 +263,15 @@ class TestDependencyManager(TestCase):
     @staticmethod
     def _convert_strings_to_paths(source_dest_list):
         return map(lambda item: (Path(item[0]), Path(item[1])), source_dest_list)
+
+
+class TestLinkSinglePathAction(TestCase):
+    @patch("aws_lambda_builders.actions.os.makedirs")
+    @patch("aws_lambda_builders.utils.create_symlink_or_copy")
+    def test_skips_non_existent_source(self, mock_create_symlink_or_copy, mock_makedirs):
+        src = "src/path"
+        dest = "dest/path"
+
+        LinkSinglePathAction(source=src, dest=dest).execute()
+        mock_create_symlink_or_copy.assert_not_called()
+        mock_makedirs.assert_not_called()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,24 +1,27 @@
 import platform
+from pathlib import Path
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock, MagicMock
 
 from aws_lambda_builders import utils
 from aws_lambda_builders.utils import decode
 
 
 class Test_create_symlink_or_copy(TestCase):
-    @patch("aws_lambda_builders.utils.Path")
     @patch("aws_lambda_builders.utils.os")
     @patch("aws_lambda_builders.utils.copytree")
-    def test_must_create_symlink_with_absolute_path(self, patched_copy_tree, pathced_os, patched_path):
+    def test_must_create_symlink_with_absolute_path(self, patched_copy_tree, patched_os):
         source_path = "source/path"
         destination_path = "destination/path"
-        utils.create_symlink_or_copy(source_path, destination_path)
 
-        pathced_os.symlink.assert_called_with(
-            patched_path(source_path).absolute(), patched_path(destination_path).absolute()
-        )
+        p = MagicMock()
+        p.return_value = False
+
+        with patch("aws_lambda_builders.utils.Path.is_symlink", p):
+            utils.create_symlink_or_copy(source_path, destination_path)
+
+        patched_os.symlink.assert_called_with(Path(source_path).absolute(), Path(destination_path).absolute())
         patched_copy_tree.assert_not_called()
 
     @patch("aws_lambda_builders.utils.Path")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -34,6 +34,17 @@ class Test_create_symlink_or_copy(TestCase):
         pathced_os.symlink.assert_called_once()
         patched_copy_tree.assert_called_with(source_path, destination_path)
 
+    @patch("aws_lambda_builders.utils.Path")
+    @patch("aws_lambda_builders.utils.os")
+    @patch("aws_lambda_builders.utils.copytree")
+    def test_must_copy_if_symlink_fails(self, patched_copy_tree, pathced_os, patched_path):
+        source_path = "source/path"
+        destination_path = "destination/path"
+        utils.create_symlink_or_copy(source_path, destination_path)
+
+        pathced_os.symlink.assert_not_called()
+        patched_copy_tree.assert_not_called()
+
 
 class TestDecode(TestCase):
     def test_does_not_crash_non_utf8_encoding(self):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
There are two scenarios fixed by this PR:
1. The symbolic link action attempts to link to a non-existent directory. This results in an error when executing `sam package`.
2. The symbolic link utility function attempts to link to an already created directory resulting in an error when using auto-dependency layer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
