### PR TITLE
fix: use npm update when building in source

### DIFF
--- a/aws_lambda_builders/actions.py
+++ b/aws_lambda_builders/actions.py
@@ -57,7 +57,7 @@ class _ActionMetaClass(type):
     def __new__(mcs, name, bases, class_dict):
         cls = type.__new__(mcs, name, bases, class_dict)
 
-        if cls.__name__ == "BaseAction":
+        if cls.__name__ in ["BaseAction", "NodejsNpmInstallOrUpdateBaseAction"]:
             return cls
 
         # Validate class variables

--- a/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm_esbuild/workflow.py
@@ -118,7 +118,7 @@ class NodejsNpmEsbuildWorkflow(BaseWorkflow):
                     subprocess_npm=self.subprocess_npm,
                     osutils=self.osutils,
                     build_options=self.options,
-                    install_links=is_building_in_source,
+                    is_building_in_source=is_building_in_source,
                 )
             )
 

--- a/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
+++ b/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
@@ -338,7 +338,7 @@ class TestNodejsNpmWorkflow(TestCase):
         # update package.json with empty one and re-run the build then confirm node_modules are cleared up
         shutil.copy2(
             os.path.join(self.temp_testdata_dir, "no-deps", "package.json"),
-            os.path.join(self.temp_testdata_dir, "npm-deps", "package.json")
+            os.path.join(self.temp_testdata_dir, "npm-deps", "package.json"),
         )
 
         self.builder.build(

--- a/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
+++ b/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
@@ -352,8 +352,8 @@ class TestNodejsNpmWorkflow(TestCase):
         # dependencies installed in source folder
         source_node_modules = os.path.join(source_dir, "node_modules")
         self.assertTrue(os.path.isdir(source_node_modules))
-        expected_node_modules_contents = {"minimal-request-promise", ".package-lock.json"}
-        self.assertEqual(set(os.listdir(source_node_modules)), expected_node_modules_contents)
+        self.assertIn(".package-lock.json", set(os.listdir(source_node_modules)))
+        self.assertNotIn("minimal-request-promise", set(os.listdir(source_node_modules)))
 
     @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_build_in_source_with_download_dependencies_local_dependency(self, runtime):

--- a/tests/unit/workflows/nodejs_npm/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm/test_workflow.py
@@ -20,6 +20,7 @@ from aws_lambda_builders.workflows.nodejs_npm.actions import (
     NodejsNpmrcCleanUpAction,
     NodejsNpmLockFileCleanUpAction,
     NodejsNpmCIAction,
+    NodejsNpmUpdateAction,
 )
 
 
@@ -107,7 +108,7 @@ class TestNodejsNpmWorkflow(TestCase):
         self.assertIsInstance(workflow.actions[3], CopySourceAction)
         self.assertEqual(workflow.actions[3].source_dir, "source")
         self.assertEqual(workflow.actions[3].dest_dir, "artifacts")
-        self.assertIsInstance(workflow.actions[4], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[4], NodejsNpmUpdateAction)
         self.assertEqual(workflow.actions[4].install_dir, "not_source")
         self.assertIsInstance(workflow.actions[5], LinkSinglePathAction)
         self.assertEqual(workflow.actions[5]._source, os.path.join("not_source", "node_modules"))
@@ -331,7 +332,7 @@ class TestNodejsNpmWorkflow(TestCase):
         self.assertIsInstance(workflow.actions[0], NodejsNpmPackAction)
         self.assertIsInstance(workflow.actions[1], NodejsNpmrcAndLockfileCopyAction)
         self.assertIsInstance(workflow.actions[2], CopySourceAction)
-        self.assertIsInstance(workflow.actions[3], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[3], NodejsNpmUpdateAction)
         self.assertEqual(workflow.actions[3].install_dir, source_dir)
         self.assertIsInstance(workflow.actions[4], LinkSinglePathAction)
         self.assertEqual(workflow.actions[4]._source, os.path.join(source_dir, "node_modules"))
@@ -358,7 +359,7 @@ class TestNodejsNpmWorkflow(TestCase):
         self.assertIsInstance(workflow.actions[0], NodejsNpmPackAction)
         self.assertIsInstance(workflow.actions[1], NodejsNpmrcAndLockfileCopyAction)
         self.assertIsInstance(workflow.actions[2], CopySourceAction)
-        self.assertIsInstance(workflow.actions[3], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[3], NodejsNpmUpdateAction)
         self.assertEqual(workflow.actions[3].install_dir, source_dir)
         self.assertIsInstance(workflow.actions[4], LinkSinglePathAction)
         self.assertEqual(workflow.actions[4]._source, os.path.join(source_dir, "node_modules"))
@@ -442,5 +443,5 @@ class TestNodejsNpmWorkflow(TestCase):
             subprocess_npm=ANY,
             osutils=ANY,
             build_options=ANY,
-            install_links=False,
+            is_building_in_source=False,
         )

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_workflow.py
@@ -12,7 +12,11 @@ from aws_lambda_builders.actions import (
     LinkSinglePathAction,
 )
 from aws_lambda_builders.architecture import ARM64
-from aws_lambda_builders.workflows.nodejs_npm.actions import NodejsNpmInstallAction, NodejsNpmCIAction
+from aws_lambda_builders.workflows.nodejs_npm.actions import (
+    NodejsNpmInstallAction,
+    NodejsNpmCIAction,
+    NodejsNpmUpdateAction,
+)
 from aws_lambda_builders.workflows.nodejs_npm_esbuild import NodejsNpmEsbuildWorkflow
 from aws_lambda_builders.workflows.nodejs_npm_esbuild.actions import EsbuildBundleAction
 from aws_lambda_builders.workflows.nodejs_npm_esbuild.esbuild import SubprocessEsbuild
@@ -313,7 +317,7 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             subprocess_npm=ANY,
             osutils=ANY,
             build_options=None,
-            install_links=False,
+            is_building_in_source=False,
         )
 
     @patch("aws_lambda_builders.workflows.nodejs_npm_esbuild.workflow.NodejsNpmEsbuildWorkflow._get_esbuild_subprocess")
@@ -360,7 +364,7 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
 
         self.assertEqual(len(workflow.actions), 2)
 
-        self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmUpdateAction)
         self.assertEqual(workflow.actions[0].install_dir, source_dir)
         self.assertIsInstance(workflow.actions[1], EsbuildBundleAction)
         self.assertEqual(workflow.actions[1]._working_directory, source_dir)
@@ -405,7 +409,7 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
 
         self.assertEqual(len(workflow.actions), 3)
 
-        self.assertIsInstance(workflow.actions[0], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmUpdateAction)
         self.assertEqual(workflow.actions[0].install_dir, "not_source")
         self.assertIsInstance(workflow.actions[1], LinkSinglePathAction)
         self.assertEqual(workflow.actions[1]._source, os.path.join("not_source", "node_modules"))
@@ -439,7 +443,7 @@ class TestNodejsNpmEsbuildWorkflow(TestCase):
             subprocess_npm=ANY,
             osutils=ANY,
             build_options=ANY,
-            install_links=False,
+            is_building_in_source=False,
         )
 
     @parameterized.expand(


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When `--build-in-source` is used, `npm install` command won't remove any dependency that is removed between 2 invocations.

This PR addresses that by adding `NodejsNpmUpdateAction` and using it when build-in-source is enabled which runs `npm --no-audit --no-save --unsafe-perm --production --no-package-lock --install-links`.

`--install-links` flag is also removed from `NodejsNpmInstallAction` which was only used for build in source workflow.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
