### PR TITLE
chore: auto close issues with stage/waiting-for-release tag when a new release is completed

### DIFF
--- a/.github/workflows/close-issue-on-release.yml
+++ b/.github/workflows/close-issue-on-release.yml
@@ -1,0 +1,21 @@
+name: Close issues on release cut
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  run-workflow:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Close issues marked
+      env:
+        REPO : ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        release_url=$(gh release view ${{ github.ref_name }} --repo $REPO --json url --jq ".url")
+        for issue_number in $(gh issue list -l "stage/waiting-for-release" --repo $REPO --json number --jq ".[].number"); do
+          gh issue close $issue_number -c "Patch is released in [${{ github.ref_name }}]($release_url). If you are AWS SAM CLI user, please wait for next AWS SAM CLI release. Closing" -r completed --repo $REPO
+        done


### PR DESCRIPTION
Adds a new GHA which will run when a release completes to close all issues with `stage/waiting-for-release` label with following message;

> Patch is released in [{release_version}](release_url). If you are AWS SAM CLI user, please wait for next AWS SAM CLI release. Closing


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
