### PR TITLE
Chore: bump version to 1.44

### DIFF
--- a/aws_lambda_builders/__init__.py
+++ b/aws_lambda_builders/__init__.py
@@ -5,5 +5,5 @@ AWS Lambda Builder Library
 # Changing version will trigger a new release!
 # Please make the version change as the last step of your development.
 
-__version__ = "1.43.0"
+__version__ = "1.44.0"
 RPC_PROTOCOL_VERSION = "0.3"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
bumps the version of lambda builders to the next version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
