### PR TITLE
fix: remove python3.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -88,7 +87,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -120,7 +118,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -154,7 +151,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -182,7 +178,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -213,7 +208,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -242,7 +236,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -267,7 +260,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -296,7 +288,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -327,7 +318,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -359,7 +349,6 @@ jobs:
         python:
           - "3.9"
           - "3.8"
-          - "3.7"
         rust:
           - stable
     steps:

--- a/aws_lambda_builders/validator.py
+++ b/aws_lambda_builders/validator.py
@@ -15,7 +15,6 @@ SUPPORTED_RUNTIMES = {
     "nodejs16.x": [ARM64, X86_64],
     "nodejs18.x": [ARM64, X86_64],
     "nodejs20.x": [ARM64, X86_64],
-    "python3.7": [X86_64],
     "python3.8": [ARM64, X86_64],
     "python3.9": [ARM64, X86_64],
     "python3.10": [ARM64, X86_64],

--- a/aws_lambda_builders/workflows/python_pip/DESIGN.md
+++ b/aws_lambda_builders/workflows/python_pip/DESIGN.md
@@ -49,7 +49,7 @@ def build_dependencies(artifacts_dir_path,
 
     :type runtime: str
     :param runtime: Python version to build dependencies for. This can
-        either be python3.7, python3.8, python3.9, python3.10, python3.11 or python3.12. These are
+        either be python3.8, python3.9, python3.10, python3.11 or python3.12. These are
         currently the only supported values.
 
     :type ui: :class:`lambda_builders.actions.python_pip.utils.UI`

--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -81,7 +81,6 @@ class UnsupportedPythonVersion(PackagerError):
 
 def get_lambda_abi(runtime):
     supported = {
-        "python3.7": "cp37m",
         "python3.8": "cp38",
         "python3.9": "cp39",
         "python3.10": "cp310",
@@ -101,7 +100,7 @@ class PythonPipDependencyBuilder(object):
 
         :type runtime: str
         :param runtime: Python version to build dependencies for. This can
-            either be python3.7, python3.8, python3.9, python3.10, python3.11 or python3.12. These are currently the
+            either be python3.8, python3.9, python3.10, python3.11 or python3.12. These are currently the
             only supported values.
 
         :type osutils: :class:`lambda_builders.utils.OSUtils`

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,6 @@
-coverage==7.2.7; python_version < '3.8'
-coverage==7.4.1; python_version >= '3.8'
-flake8==3.3.0; python_version < '3.8'
-flake8==3.8.4; python_version >= '3.8'
+coverage==7.4.1
+flake8==3.8.4
 pytest-cov==4.1.0
-
-isort>=4.2.5,<5; python_version < '3.8'
 
 # Test requirements
 pytest>=6.1.1
@@ -12,6 +8,5 @@ parameterized==0.9.0
 pyelftools~=0.30 # Used to verify the generated Go binary architecture in integration tests (utils.py)
 
 # formatter
-black==22.6.0; python_version < "3.8"
-black==24.1.1; python_version >= "3.8"
+black==24.1.1
 ruff==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
     license="Apache License 2.0",
     packages=find_packages(exclude=["tests.*", "tests"]),
     keywords="AWS Lambda Functions Building",
-    # Support 3.7 or greater
-    python_requires=(">=3.7"),
+    # Support 3.8 or greater
+    python_requires=(">=3.8"),
     entry_points={"console_scripts": ["{}=aws_lambda_builders.__main__:main".format(cmd_name)]},
     install_requires=read_requirements("base.txt") + read_requirements("python_pip.txt"),
     extras_require={"dev": read_requirements("dev.txt")},
@@ -58,7 +58,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -60,6 +60,7 @@ class TestPythonPipWorkflow(TestCase):
         )
         self.runtime_mismatch = {
             "python3.8": "python3.9",
+            "python3.9": "python3.10",
             "python3.10": "python3.9",
             "python3.11": "python3.10",
             "python3.12": "python3.11",

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -59,9 +59,7 @@ class TestPythonPipWorkflow(TestCase):
             language=self.builder.capability.language, major=sys.version_info.major, minor=sys.version_info.minor
         )
         self.runtime_mismatch = {
-            "python3.7": "python3.8",
             "python3.8": "python3.9",
-            "python3.9": "python3.7",
             "python3.10": "python3.9",
             "python3.11": "python3.10",
             "python3.12": "python3.11",
@@ -256,10 +254,7 @@ class TestPythonPipWorkflow(TestCase):
             runtime=self.runtime,
             experimental_flags=self.experimental_flags,
         )
-        if self.runtime in ("python3.7"):
-            expected_files = self.test_data_files.union(["inflate64", "inflate64-0.3.1.dist-info"])
-        else:
-            expected_files = self.test_data_files.union(["inflate64", "inflate64-1.0.0.dist-info"])
+        expected_files = self.test_data_files.union(["inflate64", "inflate64-1.0.0.dist-info"])
         output_files = set(os.listdir(self.artifacts_dir))
         for f in expected_files:
             self.assertIn(f, output_files)

--- a/tests/integration/workflows/python_pip/testdata/requirements-numpy.txt
+++ b/tests/integration/workflows/python_pip/testdata/requirements-numpy.txt
@@ -1,6 +1,3 @@
-numpy==1.15.4; python_version == '2.7'
-numpy==1.17.4; python_version == '3.6'
-numpy==1.20.3; python_version == '3.7'
 numpy==1.20.3; python_version == '3.8'
 numpy==1.20.3; python_version == '3.9'
 numpy==1.23.5; python_version == '3.10'

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -22,8 +22,8 @@ class TestRuntimeValidator(TestCase):
             validator.validate("/usr/bin/unknown_runtime")
 
     def test_validate_with_runtime_and_incompatible_architecture(self):
-        runtime_list = ["python3.7"]
+        runtime_list = ["python3.12"]
         for runtime in runtime_list:
-            validator = RuntimeValidator(runtime=runtime, architecture="arm64")
+            validator = RuntimeValidator(runtime=runtime, architecture="invalid_arch")
             with self.assertRaises(UnsupportedArchitectureError):
                 validator.validate("/usr/bin/{}".format(runtime))

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -369,7 +369,7 @@ class TestBaseWorkflow_run(TestCase):
             "artifacts_dir",
             "scratch_dir",
             "manifest_path",
-            runtime="python3.7",
+            runtime="python3.12",
             executable_search_paths=[str(pathlib.Path(os.getcwd()).parent)],
             optimizations={"a": "b"},
             options={"c": "d"},
@@ -378,7 +378,7 @@ class TestBaseWorkflow_run(TestCase):
         validator_mock = Mock()
         validator_mock.validate = Mock()
         validator_mock.validate = MagicMock(
-            side_effect=UnsupportedArchitectureError(runtime="python3.7", architecture="arm64")
+            side_effect=UnsupportedArchitectureError(runtime="python3.12", architecture="invalid_arch")
         )
 
         resolver_mock = Mock()
@@ -394,7 +394,7 @@ class TestBaseWorkflow_run(TestCase):
         with self.assertRaises(WorkflowFailedError) as ex:
             self.work.run()
 
-        self.assertIn("Architecture arm64 is not supported for runtime python3.7", str(ex.exception))
+        self.assertIn("Architecture invalid_arch is not supported for runtime python3.12", str(ex.exception))
 
 
 class TestBaseWorkflow_repr(TestCase):

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -91,9 +91,6 @@ class FakePopenOSUtils(OSUtils):
 
 
 class TestGetLambdaAbi(object):
-    def test_get_lambda_abi_python37(self):
-        assert "cp37m" == get_lambda_abi("python3.7")
-
     def test_get_lambda_abi_python38(self):
         assert "cp38" == get_lambda_abi("python3.8")
 

--- a/tests/unit/workflows/python_pip/test_validator.py
+++ b/tests/unit/workflows/python_pip/test_validator.py
@@ -17,7 +17,7 @@ class MockSubProcess(object):
 
 class TestPythonRuntimeValidator(TestCase):
     def setUp(self):
-        self.validator = PythonRuntimeValidator(runtime="python3.7", architecture="x86_64")
+        self.validator = PythonRuntimeValidator(runtime="python3.12", architecture="x86_64")
 
     def test_runtime_validate_unsupported_language_fail_open(self):
         validator = PythonRuntimeValidator(runtime="python2.6", architecture="arm64")
@@ -27,7 +27,7 @@ class TestPythonRuntimeValidator(TestCase):
     def test_runtime_validate_supported_version_runtime(self):
         with mock.patch("subprocess.Popen") as mock_subprocess:
             mock_subprocess.return_value = MockSubProcess(0)
-            self.validator.validate(runtime_path="/usr/bin/python3.7")
+            self.validator.validate(runtime_path="/usr/bin/python3.12")
             self.assertTrue(mock_subprocess.call_count, 1)
 
     def test_runtime_validate_mismatch_version_runtime(self):
@@ -38,14 +38,14 @@ class TestPythonRuntimeValidator(TestCase):
                 self.assertTrue(mock_subprocess.call_count, 1)
 
     def test_python_command(self):
-        cmd = self.validator._validate_python_cmd(runtime_path="/usr/bin/python3.7")
-        version_strings = ["sys.version_info.major == 3", "sys.version_info.minor == 7"]
+        cmd = self.validator._validate_python_cmd(runtime_path="/usr/bin/python3.12")
+        version_strings = ["sys.version_info.major == 3", "sys.version_info.minor == 12"]
         for version_string in version_strings:
             self.assertTrue(all([part for part in cmd if version_string in part]))
 
     @parameterized.expand(
         [
-            ("python3.7", "arm64"),
+            ("python3.12", "invalid_arch"),
         ]
     )
     def test_runtime_validate_with_incompatible_architecture(self, runtime, architecture):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/6298

*Description of changes:*
Removes `python3.7` support for the library and for building lambda functions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
