### PR TITLE
chore: Deprecate nodejs12.x and nodejs14.x

### DIFF
--- a/aws_lambda_builders/validator.py
+++ b/aws_lambda_builders/validator.py
@@ -10,8 +10,6 @@ from aws_lambda_builders.exceptions import UnsupportedArchitectureError, Unsuppo
 LOG = logging.getLogger(__name__)
 
 SUPPORTED_RUNTIMES = {
-    "nodejs12.x": [ARM64, X86_64],
-    "nodejs14.x": [ARM64, X86_64],
     "nodejs16.x": [ARM64, X86_64],
     "nodejs18.x": [ARM64, X86_64],
     "nodejs20.x": [ARM64, X86_64],

--- a/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
+++ b/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
@@ -41,7 +41,7 @@ class TestNodejsNpmWorkflow(TestCase):
         shutil.rmtree(self.dependencies_dir)
         shutil.rmtree(self.temp_dir)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_without_dependencies(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "no-deps")
 
@@ -57,7 +57,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_without_manifest(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "no-manifest")
 
@@ -75,7 +75,7 @@ class TestNodejsNpmWorkflow(TestCase):
         mock_warning.assert_called_once_with("package.json file not found. Continuing the build without dependencies.")
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_and_excludes_hidden_aws_sam(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "excluded-files")
 
@@ -91,7 +91,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_remote_dependencies(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "npm-deps")
 
@@ -111,7 +111,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_modules = set(os.listdir(os.path.join(self.artifacts_dir, "node_modules")))
         self.assertEqual(expected_modules, output_modules)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_npmrc(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "npmrc")
 
@@ -134,18 +134,12 @@ class TestNodejsNpmWorkflow(TestCase):
 
     @parameterized.expand(
         [
-            ("nodejs12.x", "package-lock"),
-            ("nodejs14.x", "package-lock"),
             ("nodejs16.x", "package-lock"),
             ("nodejs18.x", "package-lock"),
             ("nodejs20.x", "package-lock"),
-            ("nodejs12.x", "shrinkwrap"),
-            ("nodejs14.x", "shrinkwrap"),
             ("nodejs16.x", "shrinkwrap"),
             ("nodejs18.x", "shrinkwrap"),
             ("nodejs20.x", "shrinkwrap"),
-            ("nodejs12.x", "package-lock-and-shrinkwrap"),
-            ("nodejs14.x", "package-lock-and-shrinkwrap"),
             ("nodejs16.x", "package-lock-and-shrinkwrap"),
             ("nodejs18.x", "package-lock-and-shrinkwrap"),
             ("nodejs20.x", "package-lock-and-shrinkwrap"),
@@ -175,7 +169,7 @@ class TestNodejsNpmWorkflow(TestCase):
 
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_fails_if_npm_cannot_resolve_dependencies(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "broken-deps")
 
@@ -190,7 +184,7 @@ class TestNodejsNpmWorkflow(TestCase):
 
         self.assertIn("No matching version found for aws-sdk@2.997.999", str(ctx.exception))
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_remote_dependencies_without_download_dependencies_with_dependencies_dir(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "npm-deps")
 
@@ -208,7 +202,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_remote_dependencies_with_download_dependencies_and_dependencies_dir(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "npm-deps")
 
@@ -238,7 +232,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_dependencies_files = set(os.listdir(os.path.join(self.dependencies_dir)))
         self.assertNotIn(expected_dependencies_files, output_dependencies_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_remote_dependencies_without_download_dependencies_without_dependencies_dir(
         self, runtime
     ):
@@ -259,7 +253,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_without_combine_dependencies(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "npm-deps")
 
@@ -286,7 +280,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_dependencies_files = set(os.listdir(os.path.join(self.dependencies_dir)))
         self.assertNotIn(expected_dependencies_files, output_dependencies_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_build_in_source_with_download_dependencies(self, runtime):
         source_dir = os.path.join(self.temp_testdata_dir, "npm-deps")
 
@@ -315,7 +309,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_build_in_source_with_removed_dependencies(self, runtime):
         # run a build with default requirements and confirm dependencies are downloaded
         source_dir = os.path.join(self.temp_testdata_dir, "npm-deps")
@@ -355,7 +349,7 @@ class TestNodejsNpmWorkflow(TestCase):
         self.assertIn(".package-lock.json", set(os.listdir(source_node_modules)))
         self.assertNotIn("minimal-request-promise", set(os.listdir(source_node_modules)))
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_build_in_source_with_download_dependencies_local_dependency(self, runtime):
         source_dir = os.path.join(self.temp_testdata_dir, "with-local-dependency")
 
@@ -384,7 +378,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_build_in_source_with_download_dependencies_and_dependencies_dir(self, runtime):
         source_dir = os.path.join(self.temp_testdata_dir, "npm-deps")
 
@@ -419,7 +413,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_build_in_source_with_download_dependencies_and_dependencies_dir_without_combine_dependencies(
         self, runtime
     ):
@@ -452,7 +446,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_build_in_source_reuse_saved_dependencies_dir(self, runtime):
         source_dir = os.path.join(self.temp_testdata_dir, "npm-deps")
 
@@ -508,7 +502,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_manifest_outside_root(self, runtime):
         base_dir = os.path.join(self.temp_testdata_dir, "manifest-outside-root")
         source_dir = os.path.join(base_dir, "src")
@@ -531,7 +525,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_modules = set(os.listdir(os.path.join(self.artifacts_dir, "node_modules")))
         self.assertEqual(expected_modules, output_modules)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_manifest_outside_root_with_reuse_saved_dependencies_dir(self, runtime):
         base_dir = os.path.join(self.temp_testdata_dir, "manifest-outside-root")
         source_dir = os.path.join(base_dir, "src")
@@ -578,7 +572,7 @@ class TestNodejsNpmWorkflow(TestCase):
         output_modules = set(os.listdir(os.path.join(self.artifacts_dir, "node_modules")))
         self.assertEqual(expected_modules, output_modules)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_manifest_outside_root_with_dependencies_dir_and_not_combine(self, runtime):
         base_dir = os.path.join(self.temp_testdata_dir, "manifest-outside-root")
         source_dir = os.path.join(base_dir, "src")
@@ -603,7 +597,7 @@ class TestNodejsNpmWorkflow(TestCase):
         dependencies_dir_modules = set(os.listdir(os.path.join(self.dependencies_dir, "node_modules")))
         self.assertEqual(expected_modules, dependencies_dir_modules)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_manifest_outside_root_with_dependencies_dir_and_combine(self, runtime):
         base_dir = os.path.join(self.temp_testdata_dir, "manifest-outside-root")
         source_dir = os.path.join(base_dir, "src")
@@ -632,7 +626,7 @@ class TestNodejsNpmWorkflow(TestCase):
         dependencies_dir_modules = set(os.listdir(os.path.join(self.dependencies_dir, "node_modules")))
         self.assertEqual(expected_modules, dependencies_dir_modules)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_manifest_outside_root_and_local_dependencies(self, runtime):
         base_dir = os.path.join(self.temp_testdata_dir, "manifest-outside-root-with-local-dependency")
         source_dir = os.path.join(base_dir, "src")
@@ -660,7 +654,7 @@ class TestNodejsNpmWorkflow(TestCase):
         source_modules = set(os.listdir(os.path.join(source_dir, "node_modules")))
         self.assertTrue(all(expected_module in source_modules for expected_module in expected_modules))
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_manifest_outside_root_and_local_dependencies_with_reuse_saved_dependencies_dir(
         self, runtime
     ):
@@ -715,7 +709,7 @@ class TestNodejsNpmWorkflow(TestCase):
         source_modules = set(os.listdir(os.path.join(source_dir, "node_modules")))
         self.assertTrue(all(expected_module in source_modules for expected_module in expected_modules))
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_manifest_outside_root_and_local_dependencies_with_dependencies_dir_and_not_combine(
         self, runtime
     ):
@@ -747,7 +741,7 @@ class TestNodejsNpmWorkflow(TestCase):
         source_modules = set(os.listdir(os.path.join(source_dir, "node_modules")))
         self.assertTrue(all(expected_module in source_modules for expected_module in expected_modules))
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_manifest_outside_root_and_local_dependencies_with_dependencies_dir_and_combine(
         self, runtime
     ):

--- a/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
+++ b/tests/integration/workflows/nodejs_npm_esbuild/test_nodejs_npm_with_esbuild.py
@@ -52,7 +52,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         if os.path.exists(source_dependencies):
             shutil.rmtree(source_dependencies)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_javascript_project_with_dependencies(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild")
 
@@ -73,7 +73,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_javascript_project_with_multiple_entrypoints(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild-multiple-entrypoints")
 
@@ -94,7 +94,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_typescript_projects(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild-typescript")
 
@@ -115,7 +115,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_with_external_esbuild(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "no-deps-esbuild")
         options = {"entry_points": ["included.js"]}
@@ -135,7 +135,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_no_options_passed_to_esbuild(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild")
 
@@ -152,7 +152,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
 
         self.assertEqual(str(context.exception), "NodejsNpmEsbuildBuilder:EsbuildBundle - entry_points not set ({})")
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_bundle_with_implicit_file_types(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "implicit-file-types")
 
@@ -173,7 +173,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_bundles_project_without_dependencies(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "no-package-esbuild")
         options = {"entry_points": ["included"]}
@@ -199,7 +199,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_remote_dependencies_without_download_dependencies_with_dependencies_dir(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-no-node_modules")
         options = {"entry_points": ["included.js"]}
@@ -227,7 +227,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_remote_dependencies_with_download_dependencies_and_dependencies_dir(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-no-node_modules")
         options = {"entry_points": ["included.js"]}
@@ -257,7 +257,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_dependencies_files = set(os.listdir(os.path.join(self.dependencies_dir)))
         self.assertNotIn(expected_dependencies_files, output_dependencies_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_with_remote_dependencies_without_download_dependencies_without_dependencies_dir(
         self, runtime
     ):
@@ -282,7 +282,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
             "dependencies directory was not provided and downloading dependencies is disabled.",
         )
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_project_without_combine_dependencies(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-no-node_modules")
         options = {"entry_points": ["included.js"]}
@@ -313,7 +313,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_dependencies_files = set(os.listdir(os.path.join(self.dependencies_dir)))
         self.assertNotIn(expected_dependencies_files, output_dependencies_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_javascript_project_with_external(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild-externals")
 
@@ -338,7 +338,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
             # Check that the module has been require() instead of bundled
             self.assertIn('require("minimal-request-promise")', js_file)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_javascript_project_with_loader(self, runtime):
         osutils = OSUtils()
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "no-deps-esbuild-loader")
@@ -380,7 +380,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
             ),
         )
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_includes_sourcemap_if_requested(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild")
 
@@ -401,7 +401,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_esbuild_produces_mjs_output_files(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild")
         options = {"entry_points": ["included.js"], "sourcemap": True, "out_extension": [".js=.mjs"]}
@@ -421,7 +421,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_esbuild_produces_sourcemap_without_source_contents(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild")
         options = {"entry_points": ["included.js"], "sourcemap": True, "sources_content": "false"}
@@ -444,7 +444,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         self.assertNotIn("sourcesContent", sourcemap)
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_esbuild_can_build_in_source(self, runtime):
         options = {"entry_points": ["included.js"]}
 
@@ -470,7 +470,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_esbuild_can_build_in_source_with_local_dependency(self, runtime):
         self.source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-local-dependency")
 
@@ -498,7 +498,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_javascript_project_ignoring_relevant_flags(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps-esbuild")
 
@@ -519,7 +519,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_typescript_projects_with_external_manifest(self, runtime):
         base_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-manifest-outside-root")
         source_dir = os.path.join(base_dir, "src")
@@ -541,7 +541,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_typescript_projects_with_external_manifest_with_dependencies_dir_without_combine(self, runtime):
         base_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-manifest-outside-root")
         source_dir = os.path.join(base_dir, "src")
@@ -570,7 +570,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_modules = set(os.listdir(os.path.join(self.dependencies_dir, "node_modules")))
         self.assertIn(expected_modules, output_modules)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_typescript_projects_with_external_manifest_with_dependencies_dir_with_combine(self, runtime):
         base_dir = os.path.join(self.TEST_DATA_FOLDER, "esbuild-manifest-outside-root")
         source_dir = os.path.join(base_dir, "src")
@@ -599,7 +599,7 @@ class TestNodejsNpmWorkflowWithEsbuild(TestCase):
         output_modules = set(os.listdir(os.path.join(self.dependencies_dir, "node_modules")))
         self.assertIn(expected_modules, output_modules)
 
-    @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",), ("nodejs18.x",)])
+    @parameterized.expand([("nodejs16.x",), ("nodejs18.x",), ("nodejs20.x",)])
     def test_builds_typescript_projects_with_external_manifest_and_local_depends(self, runtime):
         base_dir = os.path.join(self.temp_testdata_dir, "esbuild-manifest-outside-root-with-local-depends")
         source_dir = os.path.join(base_dir, "src")

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_actions.py
@@ -219,7 +219,7 @@ class TestEsbuildBundleAction(TestCase):
         action = EsbuildBundleAction(
             "source",
             "artifacts",
-            {"entry_points": ["x.js"], "target": "node14"},
+            {"entry_points": ["x.js"], "target": "node20"},
             self.osutils,
             self.subprocess_esbuild,
             "package.json",
@@ -233,7 +233,7 @@ class TestEsbuildBundleAction(TestCase):
                 "--outdir=artifacts",
                 "--format=cjs",
                 "--minify",
-                "--target=node14",
+                "--target=node20",
             ],
             cwd="source",
         )
@@ -242,7 +242,7 @@ class TestEsbuildBundleAction(TestCase):
         action = EsbuildBundleAction(
             "source",
             "artifacts",
-            {"entry_points": ["x.js", "y.js"], "target": "node14"},
+            {"entry_points": ["x.js", "y.js"], "target": "node20"},
             self.osutils,
             self.subprocess_esbuild,
             "package.json",
@@ -257,7 +257,7 @@ class TestEsbuildBundleAction(TestCase):
                 "--outdir=artifacts",
                 "--format=cjs",
                 "--minify",
-                "--target=node14",
+                "--target=node20",
             ],
             cwd="source",
         )
@@ -270,7 +270,7 @@ class TestEsbuildBundleAction(TestCase):
         action = EsbuildBundleAction(
             "source",
             "artifacts",
-            {"entry_points": ["x.js", "y.js"], "target": "node14", "external": "./node_modules/*"},
+            {"entry_points": ["x.js", "y.js"], "target": "node20", "external": "./node_modules/*"},
             osutils_mock,
             self.subprocess_esbuild,
             "package.json",
@@ -289,7 +289,7 @@ class TestEsbuildBundleAction(TestCase):
                 "--outdir=artifacts",
                 "--format=cjs",
                 "--minify",
-                "--target=node14",
+                "--target=node20",
             ],
             cwd="source",
         )
@@ -303,7 +303,7 @@ class TestEsbuildBundleAction(TestCase):
         action = EsbuildBundleAction(
             "source",
             "artifacts",
-            {"entry_points": ["x.js", "y.js"], "target": "node14", "external": "./node_modules/*"},
+            {"entry_points": ["x.js", "y.js"], "target": "node20", "external": "./node_modules/*"},
             osutils_mock,
             subprocess_esbuild_mock,
             "package.json",

--- a/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
+++ b/tests/unit/workflows/nodejs_npm_esbuild/test_esbuild.py
@@ -196,7 +196,7 @@ class TestEsbuildCommandBuilder(TestCase):
             "sourcemap": False,
             "sources_content": "false",
             "format": "esm",
-            "target": "node14",
+            "target": "node20",
             "loader": [".proto=text", ".json=js"],
             "external": ["aws-sdk", "axios"],
             "out_extension": [".js=.mjs"],
@@ -212,7 +212,7 @@ class TestEsbuildCommandBuilder(TestCase):
             set(args),
             {
                 "--minify",
-                "--target=node14",
+                "--target=node20",
                 "--format=esm",
                 "--main-fields=module,main",
                 "--external:aws-sdk",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Remove runtimes deprecated by Lambda.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
