### PR TITLE
chore: remove ruby2.7 runtime support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,9 +310,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "2.7"
       - run: make init
       - run: pytest -vv tests/integration/workflows/ruby_bundler
 

--- a/aws_lambda_builders/validator.py
+++ b/aws_lambda_builders/validator.py
@@ -21,7 +21,6 @@ SUPPORTED_RUNTIMES = {
     "python3.10": [ARM64, X86_64],
     "python3.11": [ARM64, X86_64],
     "python3.12": [ARM64, X86_64],
-    "ruby2.7": [ARM64, X86_64],
     "ruby3.2": [ARM64, X86_64],
     "java8": [ARM64, X86_64],
     "java11": [ARM64, X86_64],

--- a/aws_lambda_builders/workflows/ruby_bundler/DESIGN.md
+++ b/aws_lambda_builders/workflows/ruby_bundler/DESIGN.md
@@ -64,7 +64,7 @@ bundle install --deployment
 
 ### sam build --use-container
 
-This command would use some sort of container, such as `public.ecr.aws/sam/build-ruby2.7`.
+This command would use some sort of container, such as `public.ecr.aws/sam/build-ruby3.2`.
 
 ```shell
 # exit with error if vendor/bundle and/or .bundle directory exists and is non-empty

--- a/tests/integration/workflows/ruby_bundler/test_ruby.py
+++ b/tests/integration/workflows/ruby_bundler/test_ruby.py
@@ -18,7 +18,6 @@ workflow_logger = logging.getLogger("aws_lambda_builders.workflows.ruby_bundler.
 @parameterized_class(
     ("runtime",),
     [
-        ("ruby2.7",),
         ("ruby3.2",),
     ],
 )


### PR DESCRIPTION
*Description of changes:*

Removes `ruby2.7` support for the library and for building lambda functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
