### PR TITLE
fix: Rename provided go binary to bootstrap

### DIFF
--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -32,7 +32,12 @@ class GoModulesWorkflow(BaseWorkflow):
         handler = options.get("artifact_executable_name", None)
         trim_go_path = options.get("trim_go_path", False)
 
-        output_path = osutils.joinpath(artifacts_dir, handler)
+        # For provided runtimes, the binary must be named "bootstrap"
+        output_path = (
+            osutils.joinpath(artifacts_dir, handler)
+            if runtime != "provided"
+            else osutils.joinpath(artifacts_dir, "bootstrap")
+        )
 
         builder = GoModulesBuilder(
             osutils,

--- a/tests/integration/workflows/go_modules/test_go.py
+++ b/tests/integration/workflows/go_modules/test_go.py
@@ -8,6 +8,8 @@ except ImportError:
     from pathlib2 import Path
 
 from unittest import TestCase
+from parameterized import parameterized
+
 
 from aws_lambda_builders.builder import LambdaBuilder
 from aws_lambda_builders.exceptions import WorkflowFailedError
@@ -194,5 +196,20 @@ class TestGoWorkflow(TestCase):
             options={"artifact_executable_name": "helloWorld"},
         )
         expected_files = {"helloWorld"}
+        output_files = set(os.listdir(self.artifacts_dir))
+        self.assertEqual(expected_files, output_files)
+
+    @parameterized.expand([("provided", "bootstrap"), ("go1.x", "helloWorld")])
+    def test_binary_named_bootstrap_for_provided_runtime(self, runtime, expected_binary):
+        source_dir = os.path.join(self.TEST_DATA_FOLDER, "no-deps")
+        self.builder.build(
+            source_dir,
+            self.artifacts_dir,
+            self.scratch_dir,
+            os.path.join(source_dir, "go.mod"),
+            runtime=runtime,
+            options={"artifact_executable_name": "helloWorld"},
+        )
+        expected_files = {expected_binary}
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEqual(expected_files, output_files)

--- a/tests/unit/workflows/go_modules/test_workflow.py
+++ b/tests/unit/workflows/go_modules/test_workflow.py
@@ -23,7 +23,7 @@ class TestGoModulesWorkflow(TestCase):
 
         self.assertEqual(len(workflow.actions), 1)
         self.assertIsInstance(workflow.actions[0], GoModulesBuildAction)
-        
+
     def test_workflow_sets_up_builder_actions_provided(self):
         workflow = GoModulesWorkflow(
             "source",

--- a/tests/unit/workflows/go_modules/test_workflow.py
+++ b/tests/unit/workflows/go_modules/test_workflow.py
@@ -23,6 +23,20 @@ class TestGoModulesWorkflow(TestCase):
 
         self.assertEqual(len(workflow.actions), 1)
         self.assertIsInstance(workflow.actions[0], GoModulesBuildAction)
+        
+    def test_workflow_sets_up_builder_actions_provided(self):
+        workflow = GoModulesWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "manifest",
+            runtime="provided",
+            options={"artifact_executable_name": "main"},
+        )
+
+        self.assertEqual(len(workflow.actions), 1)
+        self.assertIsInstance(workflow.actions[0], GoModulesBuildAction)
+        self.assertEqual(workflow.actions[0].output_path, "artifacts/bootstrap")
 
     def test_must_validate_architecture(self):
         workflow = GoModulesWorkflow(

--- a/tests/unit/workflows/go_modules/test_workflow.py
+++ b/tests/unit/workflows/go_modules/test_workflow.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from pathlib import Path
 
 from aws_lambda_builders.workflows.go_modules.workflow import GoModulesWorkflow
 from aws_lambda_builders.workflows.go_modules.actions import GoModulesBuildAction
@@ -36,7 +37,7 @@ class TestGoModulesWorkflow(TestCase):
 
         self.assertEqual(len(workflow.actions), 1)
         self.assertIsInstance(workflow.actions[0], GoModulesBuildAction)
-        self.assertEqual(workflow.actions[0].output_path, "artifacts/bootstrap")
+        self.assertEqual(workflow.actions[0].output_path, str(Path("artifacts", "bootstrap")))
 
     def test_must_validate_architecture(self):
         workflow = GoModulesWorkflow(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/6635

*Description of changes:*
For provided runtimes, the binary name must be "bootstrap". This causes an issue with the way Lambda builders currently resolves the handler path for Go builds where the handler points to the correct source code location, but the binary is named incorrectly to be consumed by Lambda.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
