### PR TITLE
fix: set CARGO_TARGET_DIR env var to support cargo workspace setup for sam build

### DIFF
--- a/aws_lambda_builders/workflows/rust_cargo/cargo_lambda.py
+++ b/aws_lambda_builders/workflows/rust_cargo/cargo_lambda.py
@@ -100,6 +100,12 @@ class SubprocessCargoLambda(object):
             if "RUST_LOG" not in os.environ:
                 os.environ["RUST_LOG"] = "debug"
             LOG.debug("RUST_LOG environment variable set to `%s`", os.environ.get("RUST_LOG"))
+
+        if not os.getenv("CARGO_TARGET_DIR"):
+            # This results in the "target" dir being created under the member dir of a cargo workspace
+            # This is for supporting sam build for a Cargo Workspace project
+            os.environ["CARGO_TARGET_DIR"] = "target"
+
         cargo_process = self._osutils.popen(
             command,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
*Issue #, if available:*
#634

*Description of changes:*
This is to implement the workaround as fix as suggested in https://github.com/aws/aws-lambda-builders/issues/634
to support building lambda functions configured in a cargo workspace layout.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
