### PR TITLE
chore: Improve npm install debug logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ integ-test:
 	LAMBDA_BUILDERS_DEV=1 pytest tests/integration
 
 lint:
-	# Liner performs static analysis to catch latent bugs
-	ruff aws_lambda_builders
+	# Linter performs static analysis to catch latent bugs
+	ruff check aws_lambda_builders
 
 lint-fix:
 	ruff aws_lambda_builders --fix

--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -108,7 +108,7 @@ class NodejsNpmInstallAction(NodejsNpmInstallOrUpdateBaseAction):
         :raises lambda_builders.actions.ActionFailedError: when NPM execution fails
         """
         try:
-            LOG.debug("NODEJS installing in: %s", self.install_dir)
+            LOG.debug("NODEJS installing production dependencies in: %s", self.install_dir)
 
             command = ["install", "-q", "--no-audit", "--no-save", "--unsafe-perm", "--production"]
             self.subprocess_npm.run(command, cwd=self.install_dir)
@@ -132,7 +132,7 @@ class NodejsNpmUpdateAction(NodejsNpmInstallOrUpdateBaseAction):
         :raises lambda_builders.actions.ActionFailedError: when NPM execution fails
         """
         try:
-            LOG.debug("NODEJS updating in: %s", self.install_dir)
+            LOG.debug("NODEJS updating production dependencies in: %s", self.install_dir)
 
             command = [
                 "update",

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -243,6 +243,11 @@ class NodejsNpmWorkflow(BaseWorkflow):
         if build_options and isinstance(build_options, dict):
             npm_ci_option = build_options.get("use_npm_ci", False)
 
+        LOG.debug(
+            "npm installation actions install only production dependencies. "
+            "Dev dependencies are omitted from the Lambda artifacts package"
+        )
+
         if (osutils.file_exists(lockfile_path) or osutils.file_exists(shrinkwrap_path)) and npm_ci_option:
             return NodejsNpmCIAction(
                 install_dir=install_dir, subprocess_npm=subprocess_npm, install_links=is_building_in_source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,20 @@
 [tool.ruff]
 line-length = 120
 
+[tool.ruff.lint]
+
 select = [
-    "E",  # Pycodestyle
-    "F",  # Pyflakes
-    "PL", # pylint
-    "I",  # isort
+  "E",  # Pycodestyle
+  "F",  # Pyflakes
+  "PL", # pylint
+  "I",  # isort
 ]
 ignore = ["PLR0913"]
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-branches = 13
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "E501"]
 "aws_lambda_builders/workflow.py" = ["E501"]
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-builders/issues/635

*Description of changes:*
- Adds logging to make it explicit that `sam build` only install production npm dependencies.
- Updates linting configuration to remove deprecated features

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
