### PR TITLE
fix: Change the TEMP folder for Gradle tests to home for Windows

### DIFF
--- a/tests/integration/workflows/java_gradle/test_java_gradle.py
+++ b/tests/integration/workflows/java_gradle/test_java_gradle.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+import platform
 
 from unittest import TestCase
 from pathlib import Path
@@ -36,7 +37,18 @@ class TestJavaGradle(TestCase):
 
     def setUp(self):
         self.artifacts_dir = tempfile.mkdtemp()
-        self.scratch_dir = tempfile.mkdtemp()
+
+        scratch_folder_override = None
+        if platform.system().lower() == "windows" and os.getenv("GITHUB_ACTIONS"):
+            # lucashuy: there is some really odd behaviour where
+            # gradle will refuse to work it is run within
+            # the default TEMP folder location in Github Actions
+            #
+            # use the runner's home directory as a workaround
+            scratch_folder_override = os.getenv("userprofile")
+
+        self.scratch_dir = tempfile.mkdtemp(dir=scratch_folder_override)
+
         self.dependencies_dir = tempfile.mkdtemp()
         self.builder = LambdaBuilder(language="java", dependency_manager="gradle", application_framework=None)
 


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
Something changed within the runner environment, causing all Java Gradle tests to fail with the following error message:
```
 * What went wrong:

Gradle could not start your build.
> Could not create service of type BuildLifecycleController using ServicesProvider.createBuildLifecycleController().
   > Could not create service of type BuildModelController using VintageBuildControllerProvider.createBuildModelController().
      > Could not create service of type OutputFilesRepository using ExecutionBuildServices.createOutputFilesRepository().
         > java.io.IOException: Cannot delete file: C:\Users\RUNNER~1\AppData\Local\Temp\tmpale85rhe\gradle-cache\buildOutputCleanup\buildOutputCleanup.lock
```

I still don't know why this is the case, but we can update the folder we point Gradle to, to a the home directory of the runner as a workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
