### PR TITLE
fix: Restrict the condition for Gradle JVM string 

### DIFF
--- a/aws_lambda_builders/workflows/java_gradle/gradle_validator.py
+++ b/aws_lambda_builders/workflows/java_gradle/gradle_validator.py
@@ -83,5 +83,5 @@ class GradleValidator(RuntimeValidator):
 
         for line in stdout.splitlines():
             l_dec = decode(line)
-            if "JVM" in l_dec:
+            if l_dec.startswith("JVM") or l_dec.startswith("Launcher JVM") :
                 return l_dec

--- a/aws_lambda_builders/workflows/java_gradle/gradle_validator.py
+++ b/aws_lambda_builders/workflows/java_gradle/gradle_validator.py
@@ -83,5 +83,5 @@ class GradleValidator(RuntimeValidator):
 
         for line in stdout.splitlines():
             l_dec = decode(line)
-            if l_dec.startswith("JVM") or l_dec.startswith("Launcher JVM") :
+            if l_dec.startswith("JVM") or l_dec.startswith("Launcher JVM"):
                 return l_dec

--- a/tests/unit/workflows/java_gradle/test_gradle_validator.py
+++ b/tests/unit/workflows/java_gradle/test_gradle_validator.py
@@ -69,8 +69,14 @@ class TestGradleBinaryValidator(TestCase):
         validator.validate(runtime_path=self.runtime_path)
         self.mock_log.warning.assert_called_with(GradleValidator.VERSION_STRING_WARNING, self.runtime_path)
 
-    def test_emits_warning_when_version_string_not_found(self):
-        version_string = "The Java Version:          9.0.0".encode()
+    @parameterized.expand(
+        [
+            "The Java Version:          9.0.0",
+            "Daemon JVM:    /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home (no JDK specified, using current Java home)"
+        ]
+    )
+    def test_emits_warning_when_version_string_not_found(self, path):
+        version_string = path.encode()
         self.mock_os_utils.popen.side_effect = [FakePopen(stdout=version_string, returncode=0)]
         validator = GradleValidator(
             runtime=self.runtime, architecture=self.architecture, os_utils=self.mock_os_utils, log=self.mock_log

--- a/tests/unit/workflows/java_gradle/test_gradle_validator.py
+++ b/tests/unit/workflows/java_gradle/test_gradle_validator.py
@@ -72,7 +72,7 @@ class TestGradleBinaryValidator(TestCase):
     @parameterized.expand(
         [
             "The Java Version:          9.0.0",
-            "Daemon JVM:    /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home (no JDK specified, using current Java home)"
+            "Daemon JVM:    /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home (no JDK specified, using current Java home)",
         ]
     )
     def test_emits_warning_when_version_string_not_found(self, path):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/7730

*Description of changes:*
Since `gradle --version` could return this string

```
Daemon JVM:    /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home (no JDK specified, using current Java home)
```
 we should limit the search for JVM on `Launcher JVM:` and `JVM:` only.
