### PR TITLE
feat: Add support for Ruby 3.4

### DIFF
--- a/aws_lambda_builders/validator.py
+++ b/aws_lambda_builders/validator.py
@@ -22,6 +22,7 @@ SUPPORTED_RUNTIMES = {
     "python3.13": [ARM64, X86_64],
     "ruby3.2": [ARM64, X86_64],
     "ruby3.3": [ARM64, X86_64],
+    "ruby3.4": [ARM64, X86_64],
     "java8": [ARM64, X86_64],
     "java11": [ARM64, X86_64],
     "java17": [ARM64, X86_64],

--- a/tests/integration/workflows/ruby_bundler/test_ruby.py
+++ b/tests/integration/workflows/ruby_bundler/test_ruby.py
@@ -20,6 +20,7 @@ workflow_logger = logging.getLogger("aws_lambda_builders.workflows.ruby_bundler.
     [
         ("ruby3.2",),
         ("ruby3.3",),
+        ("ruby3.4",),
     ],
 )
 class TestRubyWorkflow(TestCase):


### PR DESCRIPTION
Add support for upcoming runtime Ruby 3.4 (`ruby3.4`)

*Issue #, if available:*

*Description of changes:*

Ruby 3.4 is coming soon: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-future

The tests are parameterized, so we don't need to add any custom code to test a new version of the runtime. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
