### PR TITLE
feat: update the GLIBC version available for Python 3.12 and 3.13

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -206,7 +206,8 @@ class DependencyBuilder(object):
         "cp39": (2, 26),
         "cp310": (2, 26),
         "cp311": (2, 26),
-        "cp312": (2, 26),
+        "cp312": (2, 34),
+        "cp313": (2, 34),
     }
     # Fallback version if we're on an unknown python version
     # not in _RUNTIME_GLIBC.


### PR DESCRIPTION
*Issue #, if available:* #700

*Description of changes:* Lambdas using Python 3.12 or 3.13 as runtime use Amazon Linux 2023 instead of Amazon Linux 2 as per the [official AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported).

This PR updates the available GLIBC version to 2.34, as can be obtained by running the image in Docker
```shell
$ docker run --rm -it --entrypoint /bin/bash public.ecr.aws/lambda/provided:al2023
Unable to find image 'public.ecr.aws/lambda/provided:al2023' locally
al2023: Pulling from lambda/provided
...
Status: Downloaded newer image for public.ecr.aws/lambda/provided:al2023
bash-5.2# ldd --version
ldd (GNU libc) 2.34
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
