### PR TITLE
feat: allow manylinux 2.28 and 2.34 on python 3.12+ when compiled on a different architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint:
 	ruff check aws_lambda_builders
 
 lint-fix:
-	ruff aws_lambda_builders --fix
+	ruff check aws_lambda_builders --fix
 
 # Command to run everytime you make changes to verify everything works
 dev: lint test

--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -7,7 +7,7 @@ import logging
 import re
 import subprocess
 from email.parser import FeedParser
-from typing import Tuple, List
+from typing import List, Tuple
 
 from aws_lambda_builders.architecture import ARM64, X86_64
 from aws_lambda_builders.utils import extract_tarfile
@@ -403,14 +403,39 @@ class DependencyBuilder(object):
         """Get the list of all compatible platforms for the current architecture.
 
         Examples:
-        For python 3.11 on x86_64, this will return:
-        ['any', 'linux_x86_64', 'manylinux1_x86_64', 'manylinux2010_x86_64', 'manylinux2014_x86_64', 'manylinux_2_17_x86_64']
+        ```python
+        # Return value with python 3.11 on x86_64
+        [
+            'any',
+            'linux_x86_64',
+            'manylinux1_x86_64',
+            'manylinux2010_x86_64',
+            'manylinux2014_x86_64',
+            'manylinux_2_17_x86_64'
+        ]
 
-        For python 3.12 on x86_64, this will return:
-        ['any', 'linux_x86_64', 'manylinux1_x86_64', 'manylinux2010_x86_64', 'manylinux2014_x86_64', 'manylinux_2_17_x86_64', 'manylinux_2_28_x86_64', 'manylinux_2_34_x86_64']
+        # Return value with python 3.12 on x86_64
+        [
+            'any',
+            'linux_x86_64',
+            'manylinux1_x86_64',
+            'manylinux2010_x86_64',
+            'manylinux2014_x86_64',
+            'manylinux_2_17_x86_64',
+            'manylinux_2_28_x86_64',
+            'manylinux_2_34_x86_64'
+        ]
 
-        For python 3.13 on ARM64, this will return:
-        ['any', 'linux_aarch64', 'manylinux2014_aarch64', 'manylinux_2_17_aarch64', 'manylinux_2_28_aarch64', 'manylinux_2_34_aarch64']
+        # Return value with python 3.13 on ARM64
+        [
+            'any',
+            'linux_aarch64',
+            'manylinux2014_aarch64',
+            'manylinux_2_17_aarch64',
+            'manylinux_2_28_aarch64',
+            'manylinux_2_34_aarch64'
+        ]
+        ```
         """
         lambda_abi = get_lambda_abi(self.runtime)
         manylinux_prefix = self._GLIBC_TO_LATEST_MANYLINUX.get(self._RUNTIME_GLIBC.get(lambda_abi, self._DEFAULT_GLIBC))

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -249,13 +249,35 @@ class TestPipRunner(object):
         # for getting lambda compatible wheels.
         pip, runner = pip_factory()
         packages = ["foo", "bar", "baz"]
-        runner.download_manylinux_wheels(packages, "directory", "abi")
+        runner.download_manylinux_wheels(
+            packages,
+            "directory",
+            "abi",
+            [
+                "any",
+                "linux_x86_64",
+                "manylinux1_x86_64",
+                "manylinux2010_x86_64",
+                "manylinux2014_x86_64",
+                "manylinux_2_17_x86_64",
+            ],
+        )
         expected_prefix = [
             "download",
             "--only-binary=:all:",
             "--no-deps",
             "--platform",
+            "any",
+            "--platform",
+            "linux_x86_64",
+            "--platform",
+            "manylinux1_x86_64",
+            "--platform",
+            "manylinux2010_x86_64",
+            "--platform",
             "manylinux2014_x86_64",
+            "--platform",
+            "manylinux_2_17_x86_64",
             "--implementation",
             "cp",
             "--abi",
@@ -270,7 +292,7 @@ class TestPipRunner(object):
 
     def test_download_wheels_no_wheels(self, pip_factory):
         pip, runner = pip_factory()
-        runner.download_manylinux_wheels([], "directory", "abi")
+        runner.download_manylinux_wheels([], "directory", "abi", [])
         assert len(pip.calls) == 0
 
     def test_does_find_local_directory(self, pip_factory):


### PR DESCRIPTION
*Issue:* #700

*Description of changes:*
As described by @valerena [here](https://github.com/aws/aws-lambda-builders/issues/700#issuecomment-3049644352), when trying to build cross-architecture, the platform tags added to the pip command are not correct. With this PR, I've fixed the issue while preserving most of the original logic. The approach is to add all compatible platform tags for each python version and architecture pair to the pip command, as per the [official pip documentation](https://pip.pypa.io/en/stable/cli/pip_download/#cmdoption-platform).

The code may look a bit hacky, but I tried to change as few lines as possible. Feel free to propose improvements - I'm ready to accept them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
