### PR TITLE
feat: add python option for creating parent packages during copy

### DIFF
--- a/aws_lambda_builders/builder.py
+++ b/aws_lambda_builders/builder.py
@@ -105,7 +105,7 @@ class LambdaBuilder(object):
 
         :type options: dict
         :param options:
-            Optional dictionary of options ot pass to build action. **Not supported**.
+            Optional dictionary of options to pass to build action.
 
         :type executable_search_paths: list
         :param executable_search_paths:

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -227,7 +227,7 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
         optimizations : dict, optional
             dictionary of optimization flags to pass to the build action. **Not supported**, by default None
         options : dict, optional
-            dictionary of options ot pass to build action. **Not supported**., by default None
+            dictionary of options to pass to build action. By default None
         mode : str, optional
             Mode the build should produce, by default BuildMode.RELEASE
         download_dependencies: bool, optional

--- a/aws_lambda_builders/workflows/python_pip/DESIGN.md
+++ b/aws_lambda_builders/workflows/python_pip/DESIGN.md
@@ -147,3 +147,47 @@ bundle has an `__init__.py` and is on the `PYTHONPATH`.
 The dependencies should now be succesfully installed in the target directory.
 All the temporary/intermediate files can now be deleting including all the
 wheel files and sdists.
+
+### Configuring the builder
+
+The Lambda builder supports the following optional sub-properties of the `aws_sam` configuration property.
+
+#### `parent_python_packages`
+
+`parent_python_packages` must be a string, corresponding to a dot-separated list of parent packages to create in the destination directory. This is useful when the source code has a package structure that needs to be preserved in the built artifacts.
+
+For example, if your source code is structured like this:
+
+```
+├── app
+|   ├── main.py
+|   └── utils
+|       └── logger.py
+└── tests
+    └── unit/test_handler.py
+```
+
+Then the SAM build output will look like this:
+
+```
+└── .aws-sam
+    └── build
+       └── AppLogicalId
+          ├── main.py
+          └── utils
+                └── logger.py
+```
+
+The tests would break because `main.py` is importing `logger` as `from .utils import logger`, but the built artifacts would not have the `app` package.
+
+To fix this, you can set the `parent_python_packages` property to `app` and the SAM build output will look like this:
+
+```
+└── .aws-sam
+    └── build
+       └── AppLogicalId
+          └── app
+              ├── main.py
+              └── utils
+                    └── logger.py
+```

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -1,12 +1,12 @@
 import itertools
 from unittest import TestCase
-from unittest.mock import patch, call, Mock
+from unittest.mock import Mock, call, patch
 
 from parameterized import parameterized
 
 from aws_lambda_builders.builder import LambdaBuilder
-from aws_lambda_builders.workflow import BuildDirectory, BuildInSourceSupport, Capability, BaseWorkflow
 from aws_lambda_builders.registry import DEFAULT_REGISTRY
+from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, BuildInSourceSupport, Capability
 
 
 class TesetLambdaBuilder_init(TestCase):
@@ -193,6 +193,6 @@ class TestLambdaBuilder_build(TestCase):
         workflow_instance.run.assert_called_once()
         os_mock.path.exists.assert_called_once_with("scratch_dir")
         if scratch_dir_exists:
-            os_mock.makedirs.not_called()
+            os_mock.makedirs.assert_not_called()
         else:
             os_mock.makedirs.assert_called_once_with("scratch_dir")

--- a/tests/unit/workflows/python_pip/test_actions.py
+++ b/tests/unit/workflows/python_pip/test_actions.py
@@ -1,15 +1,17 @@
 import sys
-
 from unittest import TestCase
-from unittest.mock import patch, Mock, ANY
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 from aws_lambda_builders.actions import ActionFailedError
 from aws_lambda_builders.architecture import ARM64, X86_64
 from aws_lambda_builders.binary_path import BinaryPath
-
-from aws_lambda_builders.workflows.python_pip.actions import PythonPipBuildAction
+from aws_lambda_builders.workflows.python_pip.actions import (
+    PARENT_PYTHON_PKGS_KEY,
+    PythonCreateParentPackagesAction,
+    PythonPipBuildAction,
+)
 from aws_lambda_builders.workflows.python_pip.exceptions import MissingPipError
-from aws_lambda_builders.workflows.python_pip.packager import PackagerError, SubprocessPip
+from aws_lambda_builders.workflows.python_pip.packager import PackagerError
 
 
 class TestPythonPipBuildAction(TestCase):
@@ -185,3 +187,45 @@ class TestPythonPipBuildAction(TestCase):
             PythonPipBuildAction(Mock(), Mock(), Mock(), Mock(), Mock(), mock_binaries)._find_runtime_with_pip()
 
             self.assertEqual(str(ex.exception), "Failed to find a Python runtime containing pip on the PATH.")
+
+
+class TestPythonCreateParentPackagesAction(TestCase):
+    def setUp(self):
+        self.source = "source"
+        self.dest = "dest"
+
+        self.mock_source_dir = MagicMock(name="source_dir")
+        self.mock_source_file = MagicMock(name="source_file")
+        self.mock_dest_dir = MagicMock(name="dest_dir")
+        self.mock_dest_file = MagicMock(name="dest_file")
+        self.target_dir = MagicMock(name="target_dir")
+
+        self.mock_dest_dir.joinpath.return_value = self.target_dir
+        self.mock_source_dir.glob.return_value = [self.mock_source_file]
+        self.mock_dest_dir.__truediv__.return_value = self.mock_dest_file
+
+    def mock_source_dest(self, mock_path):
+        mock_path.side_effect = lambda x: self.mock_source_dir if x == self.source else self.mock_dest_dir
+
+    @patch("aws_lambda_builders.workflows.python_pip.actions.Path")
+    def test_skips_bad_config(self, mock_path):
+        self.mock_source_dest(mock_path)
+        action = PythonCreateParentPackagesAction(self.source, self.dest, options="not_a_dict")
+
+        action.execute()
+
+        self.mock_dest_file.rename.assert_not_called()
+
+    @patch("aws_lambda_builders.workflows.python_pip.actions.Path")
+    def test_creates_parent_packages(self, mock_path):
+        self.mock_source_dest(mock_path)
+
+        self.mock_dest_file.exists.return_value = True
+
+        action = PythonCreateParentPackagesAction(
+            self.source, self.dest, options={PARENT_PYTHON_PKGS_KEY: "foo.bar.baz"}
+        )
+
+        action.execute()
+
+        self.mock_dest_file.rename.assert_called_once_with(self.target_dir / "baz")


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sam-cli/issues/6593

*Description of changes:*

This change introduces a configuration option for the python lambda directory structure. I previously created a wrapper around sam cli to achieve this but would like to contribute the feature back to this project. The issue linked above and my [GitHub repo](https://github.com/Agnostella/samwich-cli/tree/main/docs#examples-and-advanced-usage) have examples and documentation that explain the goal of this change. Once implemented, I will need to submit a PR for aws-sam-cli as well to utilize this new optional config.

I welcome your criticism and suggestions; thank you for your time reviewing this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
