### PR TITLE
docs: update contributing guide to include ai usage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,12 @@
 *Issue #, if available:*
 
-*Description of changes:*
+### Description of changes
+
+### Description of how you validated changes
+
+### Checklist
+
+- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-lambda-builders/blob/develop/CONTRIBUTING.md#ai-usage)
 
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,16 @@ reported the issue. Please try to include as much information as you can. Detail
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
+## AI Usage
+
+While using generative AI is allowed when contributing to this project, please keep the following points in mind:
+
+* Review all code yourself before you submit it.
+* Understand all the code you have submitted in order to answer any questions the maintainers could have when reviewing your PR.
+* Avoid being overly verbose in code and testing - extra code can be hard to review.
+  * For example, avoid writing unit tests that duplicate existing ones, or test libraries that you're using.
+* Keep PR descriptions, comments, and follow ups concise.
+* Ensure AI-generated code meets the same quality standards as human-written code.
 
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:


### PR DESCRIPTION
Docs update to include information about AI contributions. Same as https://github.com/aws/aws-sam-cli/pull/8359, only updated the link in PR template to be to this repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.