### PR TITLE
fix(dependency) pin git action setup-ruby to v1.268.0 until supporting bundler v4.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,7 +294,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - uses: ruby/setup-ruby@v1
+      # Pin to specific version until Lambda Builders support bundler 4.0.0
+      - uses: ruby/setup-ruby@v1.268.0
         with:
           ruby-version: "3.2"
       - run: make init


### PR DESCRIPTION
*Issue #, if available:*
Recent update of setup-ruby@v1 implies update bundler to v4.0.0 which know to stop supporting `--without` falg used in our test: 
```
>               raise WorkflowFailedError(workflow_name=self.NAME, action_name=action.NAME, reason=str(ex))
E               aws_lambda_builders.exceptions.WorkflowFailedError: RubyBundlerBuilder:RubyBundle - Bundler Failed: The `--without` flag has been removed because it relied on being remembered

E               across bundler invocations, which bundler no longer does. Instead please use

E               `bundle config set without 'development test'`, and stop using this flag
```
### Description of changes

Pins the version of ruby GitHtub action, to before they updated to use bundler 4.0.0
diff: https://github.com/ruby/setup-ruby/compare/v1.268.0...v1.269.0

Similar to: [fix: pin ruby action to specific version by valerena · Pull Request #8491 · aws/aws-sam-cli](https://github.com/aws/aws-sam-cli/pull/8491)

### Description of how you validated changes

### Checklist

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-lambda-builders/blob/develop/CONTRIBUTING.md#ai-usage)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
