### PR TITLE
fix: remove deprecated --without option from ruby bundler

### DIFF
--- a/aws_lambda_builders/workflows/ruby_bundler/actions.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/actions.py
@@ -28,7 +28,10 @@ class RubyBundlerInstallAction(BaseAction):
     def execute(self):
         try:
             LOG.debug("Running bundle install in %s", self.source_dir)
-            self.subprocess_bundler.run(["install", "--without", "development", "test"], cwd=self.source_dir)
+            self.subprocess_bundler.run(
+                ["config", "set", "--local", "without", "development:test"], cwd=self.source_dir
+            )
+            self.subprocess_bundler.run(["install"], cwd=self.source_dir)
         except BundlerExecutionError as ex:
             raise ActionFailedError(str(ex))
 
@@ -49,9 +52,8 @@ class RubyBundlerVendorAction(BaseAction):
 
     def execute(self):
         try:
-            LOG.debug("Running bundle install --deployment in %s", self.source_dir)
-            self.subprocess_bundler.run(
-                ["install", "--deployment", "--without", "development", "test"], cwd=self.source_dir
-            )
+            LOG.debug("Running bundle install with deployment enabled in %s", self.source_dir)
+            self.subprocess_bundler.run(["config", "set", "--local", "deployment", "true"], cwd=self.source_dir)
+            self.subprocess_bundler.run(["install"], cwd=self.source_dir)
         except BundlerExecutionError as ex:
             raise ActionFailedError(str(ex))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-builders/pull/805
^ PR to pin the old version that works.

The issue is that a new version of RubyGems (4.0.0) deprecates the `--without` option that we were using to not include test and development dependencies in `sam build`. This caused any `sam build` running with that version or above to fail.

### Description of changes
Changed the bundler to not use `--without`. Previously, `--without` implicitly updated the `bundler` config to have a field like 
```
BUNDLE_WITHOUT: "development:test"
```
Now, we set the config directly. This matches with the approach from the [documentation](https://bundler.io/man/bundle-install.1.html#OPTIONS).

### Description of how you validated changes
After running `pip install -e .` in a Python environment, I tried building a Ruby function using `samdev build` (`samdev` being built with the new `aws-lambda-builders`. I confirmed that the build succeeded and successfully ignored testing dependencies. I also confirmed that this was not the case in the same environment with `sam build`.

I also confirmed that the behavior between old versions of RubyGems was the same as with the new version of `aws-lambda-builders`.

Finally, I updated the unit tests to reflect the new change.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-lambda-builders/blob/develop/CONTRIBUTING.md#ai-usage)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
