### PR TITLE
chore: updating `black` and `coverage` dependency

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
-coverage==7.10.7; python_version>="3.9"
-coverage==7.6.1; python_version<"3.9"
+coverage==7.13.4; python_version>="3.10"
+coverage==7.10.7; python_version<"3.10"
 flake8==3.8.4
 pytest-cov==6.3.0; python_version>="3.9"
 pytest-cov==5.0.0; python_version<"3.9"
@@ -10,6 +10,6 @@ parameterized==0.9.0
 pyelftools~=0.32 # Used to verify the generated Go binary architecture in integration tests (utils.py)
 
 # formatter
-black==25.11.0; python_version>="3.9"
-black==24.8.0; python_version<"3.9"
-ruff==0.15.2
+black==26.3.0; python_version>="3.10"
+black==25.11.0; python_version<"3.10"
+ruff==0.15.5

--- a/tests/functional/workflows/python_pip/test_packager.py
+++ b/tests/functional/workflows/python_pip/test_packager.py
@@ -21,7 +21,6 @@ from aws_lambda_builders.workflows.python_pip.compat import pip_no_compile_c_env
 from aws_lambda_builders.workflows.python_pip.compat import pip_no_compile_c_shim
 from aws_lambda_builders.workflows.python_pip.utils import OSUtils
 
-
 FakePipCall = namedtuple("FakePipEntry", ["args", "env_vars", "shim"])
 
 


### PR DESCRIPTION
*Issue #, if available:*

### Description of changes
Updates `coverage` to `7.13.4` and `black` to `26.3.0` for Python 3.10+, while maintaining compatibility with Python 3.9 by using `coverage 7.10.7` and `black 25.11.0` for that version.

This PR resolves the error with the following dependabot PRs:
https://github.com/aws/aws-lambda-builders/pull/842
https://github.com/aws/aws-lambda-builders/pull/838
### Description of how you validated changes
Run `make pr`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
