### PR TITLE
chore: drop Python 3.9 support for running aws-lambda-builders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -290,7 +289,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ max-branches = 13
 
 [tool.black]
 line-length = 120
-target_version = ['py37', 'py38', 'py39']
+target_version = ['py310', 'py311', 'py312', 'py313', 'py314']
 exclude = '''
 
 (

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,6 @@
-coverage==7.13.5; python_version>="3.10"
-coverage==7.10.7; python_version<"3.10"
+coverage==7.13.5
 flake8==3.8.4
-pytest-cov==6.3.0; python_version>="3.9"
-pytest-cov==5.0.0; python_version<"3.9"
+pytest-cov==6.3.0
 
 # Test requirements
 pytest>=6.1.1
@@ -10,6 +8,5 @@ parameterized==0.9.0
 pyelftools~=0.32 # Used to verify the generated Go binary architecture in integration tests (utils.py)
 
 # formatter
-black==26.3.1; python_version>="3.10"
-black==25.11.0; python_version<"3.10"
+black==26.3.1
 ruff==0.15.5

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
     license="Apache License 2.0",
     packages=find_packages(exclude=["tests.*", "tests"]),
     keywords="AWS Lambda Functions Building",
-    # Support 3.8 or greater
-    python_requires=(">=3.8"),
+    # Support 3.10 or greater
+    python_requires=(">=3.10"),
     entry_points={"console_scripts": ["{}=aws_lambda_builders.__main__:main".format(cmd_name)]},
     install_requires=read_requirements("base.txt") + read_requirements("python_pip.txt"),
     extras_require={"dev": read_requirements("dev.txt")},
@@ -58,8 +58,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/tests/unit/workflows/python_uv/test_packager.py
+++ b/tests/unit/workflows/python_uv/test_packager.py
@@ -219,9 +219,11 @@ class TestPythonUvDependencyBuilder(TestCase):
         # Mock the uv export command
         self.mock_uv_runner._uv.run_uv_command.return_value = (0, b"", b"")
 
-        with patch("os.path.basename", return_value="pyproject.toml"), patch(
-            "os.path.dirname", return_value=os.path.join("path", "to")
-        ), patch("os.path.exists") as mock_exists:
+        with (
+            patch("os.path.basename", return_value="pyproject.toml"),
+            patch("os.path.dirname", return_value=os.path.join("path", "to")),
+            patch("os.path.exists") as mock_exists,
+        ):
 
             # Mock that uv.lock exists alongside pyproject.toml
             mock_exists.return_value = True
@@ -242,9 +244,11 @@ class TestPythonUvDependencyBuilder(TestCase):
 
     def test_build_dependencies_pyproject_without_uv_lock(self):
         """Test that pyproject.toml without uv.lock uses standard pyproject build."""
-        with patch("os.path.basename", return_value="pyproject.toml"), patch(
-            "os.path.dirname", return_value=os.path.join("path", "to")
-        ), patch("os.path.exists") as mock_exists:
+        with (
+            patch("os.path.basename", return_value="pyproject.toml"),
+            patch("os.path.dirname", return_value=os.path.join("path", "to")),
+            patch("os.path.exists") as mock_exists,
+        ):
             # Mock that uv.lock does NOT exist alongside pyproject.toml
             mock_exists.return_value = False
 


### PR DESCRIPTION
## Summary

Drop Python 3.9 as a supported version for **running** aws-lambda-builders. The minimum Python version is now 3.10. CI test matrices now cover Python 3.10 through 3.14.

## What changed

- `setup.py`: `python_requires` bumped to `>=3.10`, removed 3.8/3.9 classifiers
- `.github/workflows/build.yml`: removed `3.9` from unit-functional, python-pip-integration, and python-uv-integration matrices
- `pyproject.toml`: updated black `target_version` to `py310`–`py314`
- `requirements/dev.txt`: simplified version-conditional pins that only existed for <3.10 compat

## What did NOT change

Building Lambda functions targeting the `python3.9` runtime is **still fully supported**. The `python3.9` entry in `supported_runtimes.py` and all related Lambda workflow code remains untouched. This change only affects the minimum Python version required to run aws-lambda-builders itself.