### PR TITLE
fix: exclude node 22 and npm 11 combination to fix failing CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,12 @@ jobs:
         nodejs:
           - 20
           - 22
-          - 24          
+          - 24
+        exclude:
+          # Node 22.22.2 ships broken npm missing promise-retry, preventing
+          # upgrade to npm 11. See: https://github.com/npm/cli/issues/9151
+          - nodejs: 22
+            npm: 11
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -137,6 +142,11 @@ jobs:
           - 20
           - 22
           - 24
+        exclude:
+          # Node 22.22.2 ships broken npm missing promise-retry, preventing
+          # upgrade to npm 11. See: https://github.com/npm/cli/issues/9151
+          - nodejs: 22
+            npm: 11
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
*Issue #, if available:*

### Description of changes
This PR excludes the combination of Node 22 and npm 11 from running because for those our CI is breaking. This is an issue with Node v22.22:
https://github.com/nodejs/node/issues/62425
https://github.com/npm/cli/issues/9151

An example of a failure is https://github.com/aws/aws-lambda-builders/actions/runs/24148595683/job/72751402042?pr=855

### Description of how you validated changes
The CI on this PR passing 🤞.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-lambda-builders/blob/develop/CONTRIBUTING.md#ai-usage)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
