### PR TITLE
fix(python-uv): pass --no-default-groups to uv export

### DIFF
--- a/aws_lambda_builders/workflows/python_uv/packager.py
+++ b/aws_lambda_builders/workflows/python_uv/packager.py
@@ -329,6 +329,7 @@ class PythonUvDependencyBuilder:
                 "requirements.txt",
                 "--no-emit-project",  # Don't include the project itself, only dependencies
                 "--no-hashes",  # Skip hashes for cleaner output (optional)
+                "--no-default-groups",  # Exclude PEP 735 default groups (e.g. dev/test) from Lambda zips
                 "--output-file",
                 temp_requirements,
                 # We want to specify the version because `uv export` might default to using a different one

--- a/tests/unit/workflows/python_uv/test_packager.py
+++ b/tests/unit/workflows/python_uv/test_packager.py
@@ -242,6 +242,11 @@ class TestPythonUvDependencyBuilder(TestCase):
         # Verify it checked for uv.lock in the right location
         mock_exists.assert_called_with(os.path.join("path", "to", "uv.lock"))
 
+        # Verify export excludes PEP 735 default dependency-groups (dev/test deps
+        # must not land in Lambda zips).
+        export_args = self.mock_uv_runner._uv.run_uv_command.call_args[0][0]
+        self.assertIn("--no-default-groups", export_args)
+
     def test_build_dependencies_pyproject_without_uv_lock(self):
         """Test that pyproject.toml without uv.lock uses standard pyproject build."""
         with (


### PR DESCRIPTION
### Issue

`PythonUvDependencyBuilder._build_from_lock_file` invokes \`uv export\` without \`--no-default-groups\`. Newer \`uv\` (≥ ~0.5) treats \`tool.uv.default-groups\` as \`[\"dev\"]\` by default — so any project using the PEP 735 \`[dependency-groups]\` standard with a \`dev\` group has its dev/test dependencies (\`moto\`, \`pytest\`, \`cryptography\`, \`docker\`, …) silently rolled into the exported requirements and shipped into the resulting Lambda zip.

Measured impact on a project with 9 functions on python3.14 / arm64:

| | before | after |
|---|---|---|
| `.aws-sam/build` total | 588 MB | 114 MB |
| ApiFunction zip | 98 MB | 31 MB |
| cold \`uv pip install\` per function | 144–208 s | 14–45 s |

### Fix

Add \`--no-default-groups\` to the \`uv export\` invocation in
\`aws_lambda_builders/workflows/python_uv/packager.py\`. Lambda zips are
runtime artifacts — they should never carry dev/test groups.

Users who *want* a specific group bundled can still declare it under
\`[project] dependencies\` or explicitly listed dependencies; default
groups are exactly what should be excluded from a deployable artifact.

### Test

Extended \`test_build_dependencies_pyproject_with_uv_lock\` to assert
\`--no-default-groups\` is present in the export args. Test fails without
the source change (verified by temporarily removing the line locally:
\`AssertionError: '--no-default-groups' not found in [...]\`) and passes
with it.

### Compatibility

\`--no-default-groups\` has been available in \`uv\` since the
introduction of the dependency-groups feature (well before \`uv\` 0.5).
Older \`uv\` versions without PEP 735 support simply ignore the flag (no
default groups to skip). No new flag is added to the AWS Lambda
Builders API; behavior change is contained to the implicit zip
contents — which already silently changed when \`uv\` began including
default groups in exports.