### PR TITLE
fix(python-uv): cached build copies dependencies to the build dir

### DIFF
--- a/aws_lambda_builders/workflows/python_uv/packager.py
+++ b/aws_lambda_builders/workflows/python_uv/packager.py
@@ -136,8 +136,10 @@ class UvRunner:
         # Add requirements file
         args.extend(["-r", requirements_path])
 
-        # Add target directory
-        args.extend(["--target", target_dir])
+        # Resolve --target to an absolute path: UV runs with cwd set to the project directory, so a
+        # relative target (e.g. the incremental-build dependencies dir) would otherwise be created
+        # under the source directory instead of the build root.
+        args.extend(["--target", os.path.abspath(target_dir)])
 
         # Add configuration arguments
         args.extend(config.to_uv_args())

--- a/aws_lambda_builders/workflows/python_uv/workflow.py
+++ b/aws_lambda_builders/workflows/python_uv/workflow.py
@@ -139,13 +139,15 @@ class PythonUvWorkflow(BaseWorkflow):
                 )
             )
 
-        # Advanced case: Copy dependencies from dependencies_dir to artifacts_dir if configured
+        # Advanced case: copy dependencies from dependencies_dir to artifacts_dir if configured.
+        # Dependencies were installed into dependencies_dir above, so that is the copy source
+        # (artifact_dir) and artifacts_dir is the destination.
         if self.dependencies_dir and self.combine_dependencies:
             self.actions.append(
                 CopyDependenciesAction(
                     source_dir=source_dir,
-                    artifact_dir=artifacts_dir,
-                    destination_dir=self.dependencies_dir,
+                    artifact_dir=self.dependencies_dir,
+                    destination_dir=artifacts_dir,
                     maintain_symlinks=False,
                 )
             )

--- a/tests/integration/workflows/python_uv/test_python_uv.py
+++ b/tests/integration/workflows/python_uv/test_python_uv.py
@@ -121,6 +121,9 @@ class TestPythonUvWorkflow(TestCase):
         dependencies_files = set(os.listdir(self.dependencies_dir))
         self.assertEqual(expected_dependencies.intersection(dependencies_files), expected_dependencies)
 
+        # combine_dependencies defaults to True, so dependencies must also be copied into the artifacts dir.
+        self.assertEqual(expected_dependencies.intersection(output_files), expected_dependencies)
+
     @skipIf(which("uv") is None, "uv not available")
     def test_workflow_builds_numpy_successfully(self):
         """Test that UV can build numpy (same as PIP workflow test)"""

--- a/tests/unit/workflows/python_uv/test_packager.py
+++ b/tests/unit/workflows/python_uv/test_packager.py
@@ -125,6 +125,22 @@ class TestUvRunner(TestCase):
         self.assertIn("-r", args_called)
         self.assertIn("/path/to/requirements.txt", args_called)
 
+    def test_install_requirements_resolves_relative_target_to_absolute(self):
+        # UV runs with cwd=project_dir, so a relative --target must be resolved to an absolute path
+        # first, otherwise dependencies land under the source dir instead of the build root.
+        self.mock_subprocess_uv.run_uv_command.return_value = (0, "success", "")
+
+        self.uv_runner.install_requirements(
+            requirements_path="/path/to/requirements.txt",
+            target_dir=os.path.join(".aws-sam", "deps", "abc-123"),
+            scratch_dir="/scratch",
+        )
+
+        args_called = self.mock_subprocess_uv.run_uv_command.call_args[0][0]
+        target_value = args_called[args_called.index("--target") + 1]
+        self.assertTrue(os.path.isabs(target_value), f"--target should be absolute, got: {target_value}")
+        self.assertEqual(target_value, os.path.abspath(os.path.join(".aws-sam", "deps", "abc-123")))
+
     def test_install_requirements_failure(self):
         self.mock_subprocess_uv.run_uv_command.return_value = (1, "", "error message")
 

--- a/tests/unit/workflows/python_uv/test_workflow.py
+++ b/tests/unit/workflows/python_uv/test_workflow.py
@@ -74,6 +74,13 @@ class TestPythonUvWorkflow(TestCase):
         self.assertIsInstance(self.workflow.actions[2], CopyDependenciesAction)
         self.assertIsInstance(self.workflow.actions[3], CopySourceAction)
 
+        # Dependencies are installed into dependencies_dir, then copied into artifacts_dir;
+        # artifact_dir is the copy source and dest_dir the destination (must not be swapped).
+        copy_deps_action = self.workflow.actions[2]
+        self.assertEqual(copy_deps_action.source_dir, "source")
+        self.assertEqual(copy_deps_action.artifact_dir, "deps")
+        self.assertEqual(copy_deps_action.dest_dir, "artifacts")
+
     def test_workflow_sets_up_actions_without_download_dependencies_and_dependencies_dir(self):
         self.workflow = PythonUvWorkflow(
             "source",


### PR DESCRIPTION
### Issue

Fixes #864.

\`sam build --cached --beta-features\` against a project using the
python-uv workflow fails with:

\`\`\`
Build Failed
Error: PythonUvBuilder:CopyDependencies - [Errno 2] No such file or directory: '.aws-sam/build/<FunctionName>'
\`\`\`

The failure is also destructive — it wipes \`.aws-sam/build/\` for every
function, forcing a full \`sam build --beta-features\` to recover.

### Root cause

\`sam build --cached\` runs the workflow with a \`dependencies_dir\` set
(\`.aws-sam/deps/<uuid>\`) so deps can be reused across builds. Two bugs
on that path:

1. **\`PythonUvWorkflow._setup_build_actions\` constructs \`CopyDependenciesAction\` with the source/destination swapped.** Dependencies are installed into \`dependencies_dir\`, so that is the source of the copy and \`artifacts_dir\` the destination. As written, the action listed the not-yet-created \`artifacts_dir\` as source and never populated it — hence the \`[Errno 2]\`.

2. **\`UvRunner.install_requirements\` passes \`--target\` to UV verbatim.** UV runs with \`cwd\` set to the project directory, so a relative \`.aws-sam/deps/<uuid>\` target is resolved under the source dir, not the build root. \`uv pip install\` succeeds but writes to the wrong place — the cached path then can't find the deps.

### Fix

- Swap the \`CopyDependenciesAction\` arguments in \`workflow.py\` so it copies from \`dependencies_dir\` → \`artifacts_dir\`.
- Resolve \`--target\` to an absolute path before invoking UV in \`packager.py\`.

### Tests

- Unit test in \`test_workflow.py\` asserts \`CopyDependenciesAction\` is constructed with the correct source/artifact/destination wiring.
- Unit test in \`test_packager.py\` asserts a relative \`--target\` is made absolute.
- Existing \`dependencies_dir\` integration test now asserts deps end up in \`artifacts_dir\` (previously only checked that the build didn't crash).

Verified locally: \`sam build --cached --parallel --beta-features\` now
succeeds end-to-end on a 9-function python-uv project.