### PR TITLE
Remove deprecated `--unsafe-perm` from npm commands

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -111,7 +111,7 @@ class NodejsNpmInstallAction(NodejsNpmInstallOrUpdateBaseAction):
         try:
             LOG.debug("NODEJS installing production dependencies in: %s", self.install_dir)
 
-            command = ["install", "-q", "--no-audit", "--no-save", "--unsafe-perm", "--omit=dev"]
+            command = ["install", "-q", "--no-audit", "--no-save", "--omit=dev"]
             self.subprocess_npm.run(command, cwd=self.install_dir)
 
         except NpmExecutionError as ex:
@@ -139,7 +139,6 @@ class NodejsNpmUpdateAction(NodejsNpmInstallOrUpdateBaseAction):
                 "update",
                 "--no-audit",
                 "--no-save",
-                "--unsafe-perm",
                 "--omit=dev",
                 "--no-package-lock",
                 "--install-links",

--- a/tests/unit/workflows/nodejs_npm/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm/test_actions.py
@@ -67,7 +67,7 @@ class TestNodejsNpmInstallAction(TestCase):
 
         action.execute()
 
-        expected_args = ["install", "-q", "--no-audit", "--no-save", "--unsafe-perm", "--omit=dev"]
+        expected_args = ["install", "-q", "--no-audit", "--no-save", "--omit=dev"]
 
         subprocess_npm.run.assert_called_with(expected_args, cwd="artifacts")
 


### PR DESCRIPTION
*Issue #, if available:* #893 

### Description of changes

Removes deprecated `--unsafe-perm` flag from npm commands.

### Description of how you validated changes

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-lambda-builders/blob/develop/CONTRIBUTING.md#ai-usage)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
