### PR TITLE
fix: use pre-installed Amazon.Lambda.Tools for dotnet6 builds

### DIFF
--- a/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
@@ -28,9 +28,21 @@ class GlobalToolInstallAction(BaseAction):
     DESCRIPTION = "Install or update the Amazon.Lambda.Tools .NET Core Global Tool."
     PURPOSE = Purpose.COMPILE_SOURCE
 
-    def __init__(self, subprocess_dotnet):
+    def __init__(self, subprocess_dotnet, runtime=None):
         super(GlobalToolInstallAction, self).__init__()
         self.subprocess_dotnet = subprocess_dotnet
+        self.runtime = runtime
+
+    def _existing_tool_available(self):
+        """
+        Returns True if a working Amazon.Lambda.Tools is already available on the PATH
+        (e.g. pre-installed in the SAM build image).
+        """
+        try:
+            self.subprocess_dotnet.run(["lambda", "help"])
+            return True
+        except DotnetCLIExecutionError:
+            return False
 
     def execute(self):
         # run Amazon.Lambda.Tools update in sync block in case build is triggered in parallel
@@ -40,6 +52,14 @@ class GlobalToolInstallAction(BaseAction):
             # check if Amazon.Lambda.Tools updated recently
             if GlobalToolInstallAction.__tools_installed:
                 LOG.info("Skipping to update Amazon.Lambda.Tools install/update, since it is updated recently")
+                return
+
+            # Amazon.Lambda.Tools 7.0.0 dropped support for dotnet6 (EOL runtime), so
+            # installing/updating to latest breaks dotnet6 builds. If a working tool is
+            # already available (e.g. pre-installed in the SAM build image), use it as is.
+            if self.runtime == "dotnet6" and self._existing_tool_available():
+                LOG.info("Skipping Amazon.Lambda.Tools install/update for dotnet6; using the pre-installed version")
+                GlobalToolInstallAction.__tools_installed = True
                 return
 
             try:

--- a/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
@@ -57,9 +57,10 @@ class GlobalToolInstallAction(BaseAction):
             # Amazon.Lambda.Tools 7.0.0 dropped support for dotnet6 (EOL runtime), so
             # installing/updating to latest breaks dotnet6 builds. If a working tool is
             # already available (e.g. pre-installed in the SAM build image), use it as is.
+            # Deliberately not setting __tools_installed here so other runtimes in the
+            # same process still install/update to latest as before.
             if self.runtime == "dotnet6" and self._existing_tool_available():
                 LOG.info("Skipping Amazon.Lambda.Tools install/update for dotnet6; using the pre-installed version")
-                GlobalToolInstallAction.__tools_installed = True
                 return
 
             try:

--- a/aws_lambda_builders/workflows/dotnet_clipackage/workflow.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/workflow.py
@@ -29,7 +29,7 @@ class DotnetCliPackageWorkflow(BaseWorkflow):
 
         options = kwargs["options"] if "options" in kwargs else {}
         subprocess_dotnetcli = SubprocessDotnetCLI(os_utils=OSUtils())
-        dotnetcli_install = GlobalToolInstallAction(subprocess_dotnet=subprocess_dotnetcli)
+        dotnetcli_install = GlobalToolInstallAction(subprocess_dotnet=subprocess_dotnetcli, runtime=runtime)
 
         dotnetcli_deployment = RunPackageAction(
             source_dir,

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -85,16 +85,19 @@ class TestGlobalToolInstallAction(TestCase):
             ["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
         )
 
-    def test_dotnet8_after_dotnet6_skip_uses_existing_tool(self):
-        # dotnet6 skips because a working tool is pre-installed; a subsequent dotnet8 build
-        # in the same process also skips (single install per process), using the same tool
+    def test_dotnet8_after_dotnet6_skip_still_installs(self):
+        # dotnet6 skips because a working tool is pre-installed, but it must NOT mark the
+        # tool as installed for the process - a subsequent dotnet8 build still installs
+        # or updates to latest as before
         dotnet6_action = GlobalToolInstallAction(self.subprocess_dotnet, runtime="dotnet6")
         dotnet6_action.execute()
         self.subprocess_dotnet.reset_mock()
 
         dotnet8_action = GlobalToolInstallAction(self.subprocess_dotnet, runtime="dotnet8")
         dotnet8_action.execute()
-        self.subprocess_dotnet.run.assert_not_called()
+        self.subprocess_dotnet.run.assert_called_once_with(
+            ["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
+        )
 
 
 class TestRunPackageAction(TestCase):

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -62,6 +62,40 @@ class TestGlobalToolInstallAction(TestCase):
             ["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
         )
 
+    def test_dotnet6_skips_install_when_tool_preinstalled(self):
+        # `dotnet lambda help` succeeds -> a working tool is already available (e.g. SAM build image)
+        action = GlobalToolInstallAction(self.subprocess_dotnet, runtime="dotnet6")
+        action.execute()
+        self.subprocess_dotnet.run.assert_called_once_with(["lambda", "help"])
+
+    def test_dotnet6_installs_when_no_tool_preinstalled(self):
+        # `dotnet lambda help` fails -> no tool available, fall back to normal install
+        self.subprocess_dotnet.run.side_effect = [DotnetCLIExecutionError(message="No tool"), None]
+        action = GlobalToolInstallAction(self.subprocess_dotnet, runtime="dotnet6")
+        action.execute()
+        self.subprocess_dotnet.run.assert_any_call(["lambda", "help"])
+        self.subprocess_dotnet.run.assert_any_call(
+            ["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
+        )
+
+    def test_other_runtimes_do_not_probe_for_preinstalled_tool(self):
+        action = GlobalToolInstallAction(self.subprocess_dotnet, runtime="dotnet8")
+        action.execute()
+        self.subprocess_dotnet.run.assert_called_once_with(
+            ["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
+        )
+
+    def test_dotnet8_after_dotnet6_skip_uses_existing_tool(self):
+        # dotnet6 skips because a working tool is pre-installed; a subsequent dotnet8 build
+        # in the same process also skips (single install per process), using the same tool
+        dotnet6_action = GlobalToolInstallAction(self.subprocess_dotnet, runtime="dotnet6")
+        dotnet6_action.execute()
+        self.subprocess_dotnet.reset_mock()
+
+        dotnet8_action = GlobalToolInstallAction(self.subprocess_dotnet, runtime="dotnet8")
+        dotnet8_action.execute()
+        self.subprocess_dotnet.run.assert_not_called()
+
 
 class TestRunPackageAction(TestCase):
     @patch("aws_lambda_builders.workflows.dotnet_clipackage.dotnetcli.SubprocessDotnetCLI")


### PR DESCRIPTION
*Issue #, if available:*

### Description of changes
Amazon.Lambda.Tools 7.0.0 dropped support for .NET 6 (net6.0), only supporting net8.0 and net10.0. The
GlobalToolInstall action always installs/updates the tool to latest at build time, so dotnet6 container builds (sam 
build --use-container) fail with NU1202 — even though the SAM build image already ships a working, net6-compatible
version of the tool (currently 6.0.6 at /var/lang/bin).

This change makes GlobalToolInstallAction runtime-aware, for dotnet6 only:

- Probe for a working tool first (dotnet lambda help). If one is available (e.g. pre-installed in the SAM build
image), skip the install/update and use it as is.
- If no tool is available (e.g. local builds outside the build image), fall back to the existing install behavior
unchanged.
- The skip deliberately does not set the process-wide __tools_installed flag, so other runtimes in the same process
still install/update to latest exactly as before.

All other runtimes are unaffected — the probe only runs for dotnet6.

Version-pinning approaches were considered and rejected: NuGet refuses in-place downgrades (tool update --version X
fails when a higher version is installed, and --allow-downgrade only suppresses the warning), and a hardcoded version
in lambda-builders would duplicate ownership of the tool version that belongs to the build image.


### Description of how you validated changes

- Unit tests added: dotnet6 skips when a tool is pre-installed; dotnet6 falls back to install when absent; other
runtimes never probe; a dotnet8 build after a dotnet6 skip still installs/updates as before. Full unit suite passes
(810 tests).
- End-to-end validated on x86_64: applied this patch to the lambda-builders venv inside the published
public.ecr.aws/sam/build-dotnet6:latest-x86_64 image, then ran sam build --use-container on a sam init dotnet6
hello-world app:
  - Unpatched published image: fails with NU1202 (tool update pulls 7.0.0)
  - Patched image: probe detects the pre-installed Amazon.Lambda.Tools 6.0.6, logs "Skipping Amazon.Lambda.Tools
install/update for dotnet6; using the pre-installed version", and the build succeeds.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-lambda-builders/blob/develop/CONTRIBUTING.md#ai-usage)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
