### PR TITLE
fix: skip binary validation for copy-only workflows

### DIFF
--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -70,8 +70,16 @@ def sanitize(func):  # pylint: disable=too-many-statements
         valid_paths = {}
         invalid_paths = {}
         validation_errors = []
+        binaries = self.binaries
+
+        if not binaries:
+            try:
+                RuntimeValidator(runtime=self.runtime, architecture=self.architecture).validate(None)
+            except RuntimeValidatorError as ex:
+                validation_errors.append(str(ex))
+
         # NOTE: we need to access binaries to get paths and resolvers, before validating.
-        for binary, binary_checker in self.binaries.items():
+        for binary, binary_checker in binaries.items():
             invalid_paths[binary] = []
             try:
                 exec_paths = (
@@ -103,8 +111,8 @@ def sanitize(func):  # pylint: disable=too-many-statements
                 workflow_name=self.NAME, action_name="Validation", reason="\n".join(validation_errors)
             )
 
-        if len(self.binaries) != len(valid_paths):
-            validation_failed_binaries = set(self.binaries.keys()).difference(valid_paths.keys())
+        if len(binaries) != len(valid_paths):
+            validation_failed_binaries = set(binaries.keys()).difference(valid_paths.keys())
             for validation_failed_binary in validation_failed_binaries:
                 message = "Binary validation failed for {0}, searched for {0} in following locations  : {1} which did not satisfy constraints for runtime: {2}. Do you have {0} for runtime: {2} on your PATH?".format(
                     validation_failed_binary, invalid_paths[validation_failed_binary], self.runtime

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -58,6 +58,12 @@ class BuildInSourceSupport(Enum):
     EXCLUSIVELY_SUPPORTED = [True]
 
 
+def _validate_runtime_without_binary(workflow):
+    runtime_validator = workflow.get_runtime_validator()
+    if runtime_validator:
+        runtime_validator.validate(None)
+
+
 # TODO: Move sanitize out to its own class.
 def sanitize(func):  # pylint: disable=too-many-statements
     """
@@ -74,7 +80,7 @@ def sanitize(func):  # pylint: disable=too-many-statements
 
         if not binaries:
             try:
-                RuntimeValidator(runtime=self.runtime, architecture=self.architecture).validate(None)
+                _validate_runtime_without_binary(self)
             except RuntimeValidatorError as ex:
                 validation_errors.append(str(ex))
 
@@ -337,6 +343,10 @@ class BaseWorkflow(object, metaclass=_WorkflowMetaClass):
         No-op validator that does not validate the runtime_path.
         """
         return [RuntimeValidator(runtime=self.runtime, architecture=self.architecture)]
+
+    def get_runtime_validator(self):
+        """Return the validator used when the workflow does not require any binaries."""
+        return RuntimeValidator(runtime=self.runtime, architecture=self.architecture)
 
     @property
     def binaries(self):

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -13,9 +13,7 @@ from aws_lambda_builders.actions import (
     LinkSinglePathAction,
     MoveDependenciesAction,
 )
-from aws_lambda_builders.exceptions import RuntimeValidatorError, WorkflowFailedError
 from aws_lambda_builders.path_resolver import PathResolver
-from aws_lambda_builders.validator import RuntimeValidator
 from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, BuildInSourceSupport, Capability
 from aws_lambda_builders.workflows.nodejs_npm.actions import (
     NodejsNpmCIAction,
@@ -221,17 +219,6 @@ class NodejsNpmWorkflow(BaseWorkflow):
         if not self._use_npm:
             return []
         return super().get_validators()
-
-    def run(self):
-        if not self._use_npm:
-            self._validate_runtime()
-        return super().run()
-
-    def _validate_runtime(self):
-        try:
-            RuntimeValidator(runtime=self.runtime, architecture=self.architecture).validate(None)
-        except RuntimeValidatorError as ex:
-            raise WorkflowFailedError(workflow_name=self.NAME, action_name="Validation", reason=str(ex)) from ex
 
     @staticmethod
     def get_install_action(

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -67,8 +67,9 @@ class NodejsNpmWorkflow(BaseWorkflow):
         if osutils is None:
             osutils = OSUtils()
         self.osutils = osutils
+        self._use_npm = osutils.file_exists(manifest_path)
 
-        if not osutils.file_exists(manifest_path):
+        if not self._use_npm:
             LOG.warning("package.json file not found. Continuing the build without dependencies.")
             self.actions = [CopySourceAction(source_dir, artifacts_dir, excludes=self.EXCLUDED_FILES)]
             return
@@ -210,7 +211,14 @@ class NodejsNpmWorkflow(BaseWorkflow):
         """
         specialized path resolver that just returns the list of executable for the runtime on the path.
         """
+        if not self._use_npm:
+            return []
         return [PathResolver(runtime=self.runtime, binary="npm")]
+
+    def get_validators(self):
+        if not self._use_npm:
+            return []
+        return super().get_validators()
 
     @staticmethod
     def get_install_action(

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -13,7 +13,9 @@ from aws_lambda_builders.actions import (
     LinkSinglePathAction,
     MoveDependenciesAction,
 )
+from aws_lambda_builders.exceptions import RuntimeValidatorError, WorkflowFailedError
 from aws_lambda_builders.path_resolver import PathResolver
+from aws_lambda_builders.validator import RuntimeValidator
 from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, BuildInSourceSupport, Capability
 from aws_lambda_builders.workflows.nodejs_npm.actions import (
     NodejsNpmCIAction,
@@ -219,6 +221,17 @@ class NodejsNpmWorkflow(BaseWorkflow):
         if not self._use_npm:
             return []
         return super().get_validators()
+
+    def run(self):
+        if not self._use_npm:
+            self._validate_runtime()
+        return super().run()
+
+    def _validate_runtime(self):
+        try:
+            RuntimeValidator(runtime=self.runtime, architecture=self.architecture).validate(None)
+        except RuntimeValidatorError as ex:
+            raise WorkflowFailedError(workflow_name=self.NAME, action_name="Validation", reason=str(ex)) from ex
 
     @staticmethod
     def get_install_action(

--- a/aws_lambda_builders/workflows/python_uv/workflow.py
+++ b/aws_lambda_builders/workflows/python_uv/workflow.py
@@ -173,3 +173,7 @@ class PythonUvWorkflow(BaseWorkflow):
         external validation of Python runtime paths.
         """
         return []
+
+    def get_runtime_validator(self):
+        """UV manages the requested Python runtime without BaseWorkflow validation."""
+        return None

--- a/aws_lambda_builders/workflows/ruby_bundler/workflow.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/workflow.py
@@ -5,6 +5,8 @@ Ruby Bundler Workflow
 import logging
 
 from aws_lambda_builders.actions import CleanUpAction, CopyDependenciesAction, CopySourceAction
+from aws_lambda_builders.exceptions import RuntimeValidatorError, WorkflowFailedError
+from aws_lambda_builders.validator import RuntimeValidator
 from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, BuildInSourceSupport, Capability
 
 from .actions import RubyBundlerInstallAction, RubyBundlerVendorAction
@@ -73,3 +75,14 @@ class RubyBundlerWorkflow(BaseWorkflow):
         if not self._use_bundler:
             return []
         return super().get_validators()
+
+    def run(self):
+        if not self._use_bundler:
+            self._validate_runtime()
+        return super().run()
+
+    def _validate_runtime(self):
+        try:
+            RuntimeValidator(runtime=self.runtime, architecture=self.architecture).validate(None)
+        except RuntimeValidatorError as ex:
+            raise WorkflowFailedError(workflow_name=self.NAME, action_name="Validation", reason=str(ex)) from ex

--- a/aws_lambda_builders/workflows/ruby_bundler/workflow.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/workflow.py
@@ -5,8 +5,6 @@ Ruby Bundler Workflow
 import logging
 
 from aws_lambda_builders.actions import CleanUpAction, CopyDependenciesAction, CopySourceAction
-from aws_lambda_builders.exceptions import RuntimeValidatorError, WorkflowFailedError
-from aws_lambda_builders.validator import RuntimeValidator
 from aws_lambda_builders.workflow import BaseWorkflow, BuildDirectory, BuildInSourceSupport, Capability
 
 from .actions import RubyBundlerInstallAction, RubyBundlerVendorAction
@@ -75,14 +73,3 @@ class RubyBundlerWorkflow(BaseWorkflow):
         if not self._use_bundler:
             return []
         return super().get_validators()
-
-    def run(self):
-        if not self._use_bundler:
-            self._validate_runtime()
-        return super().run()
-
-    def _validate_runtime(self):
-        try:
-            RuntimeValidator(runtime=self.runtime, architecture=self.architecture).validate(None)
-        except RuntimeValidatorError as ex:
-            raise WorkflowFailedError(workflow_name=self.NAME, action_name="Validation", reason=str(ex)) from ex

--- a/aws_lambda_builders/workflows/ruby_bundler/workflow.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/workflow.py
@@ -34,6 +34,8 @@ class RubyBundlerWorkflow(BaseWorkflow):
             source_dir, artifacts_dir, scratch_dir, manifest_path, runtime=runtime, **kwargs
         )
 
+        self._use_bundler = self.download_dependencies
+
         if osutils is None:
             osutils = OSUtils()
 
@@ -61,3 +63,13 @@ class RubyBundlerWorkflow(BaseWorkflow):
                 "download_dependencies is False and dependencies_dir is None. Copying the source files into the "
                 "artifacts directory. "
             )
+
+    def get_resolvers(self):
+        if not self._use_bundler:
+            return []
+        return super().get_resolvers()
+
+    def get_validators(self):
+        if not self._use_bundler:
+            return []
+        return super().get_validators()

--- a/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
+++ b/tests/integration/workflows/nodejs_npm/test_nodejs_npm.py
@@ -70,7 +70,12 @@ class TestNodejsNpmWorkflow(TestCase):
     def test_builds_project_without_manifest(self, runtime):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "no-manifest")
 
-        with mock.patch.object(logger, "warning") as mock_warning:
+        with (
+            mock.patch.object(logger, "warning") as mock_warning,
+            mock.patch(
+                "aws_lambda_builders.path_resolver.which", side_effect=AssertionError("npm should not be resolved")
+            ),
+        ):
             self.builder.build(
                 source_dir,
                 self.artifacts_dir,

--- a/tests/integration/workflows/ruby_bundler/test_ruby.py
+++ b/tests/integration/workflows/ruby_bundler/test_ruby.py
@@ -135,7 +135,12 @@ class TestRubyWorkflow(TestCase):
 
     def test_builds_project_without_downloaded_dependencies_without_dependencies_dir(self):
         source_dir = os.path.join(self.TEST_DATA_FOLDER, "with-deps")
-        with mock.patch.object(workflow_logger, "info") as mock_info:
+        with (
+            mock.patch.object(workflow_logger, "info") as mock_info,
+            mock.patch(
+                "aws_lambda_builders.path_resolver.which", side_effect=AssertionError("Ruby should not be resolved")
+            ),
+        ):
             self.builder.build(
                 source_dir,
                 self.artifacts_dir,

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -396,6 +396,46 @@ class TestBaseWorkflow_run(TestCase):
 
         self.assertIn("Architecture invalid_arch is not supported for runtime python3.12", str(ex.exception))
 
+    def test_empty_binaries_with_supported_runtime_executes_actions(self):
+        self.work.runtime = "python3.12"
+        self.work.architecture = "arm64"
+        self.work.get_resolvers = Mock(return_value=[])
+        self.work.get_validators = Mock(return_value=[])
+        action_mock = Mock()
+        self.work.actions = [action_mock]
+
+        self.work.run()
+
+        self.work.get_resolvers.assert_called_once_with()
+        self.work.get_validators.assert_called_once_with()
+        action_mock.execute.assert_called_once_with()
+
+    def test_empty_binaries_with_unsupported_runtime_raises_workflow_failed_error(self):
+        self.work.runtime = "python1.0"
+        self.work.get_resolvers = Mock(return_value=[])
+        self.work.get_validators = Mock(return_value=[])
+        self.work.actions = [Mock()]
+
+        with self.assertRaises(WorkflowFailedError) as raised:
+            self.work.run()
+
+        self.assertEqual(str(raised.exception), "MyWorkflow:Validation - Runtime python1.0 is not supported")
+
+    def test_empty_binaries_with_unsupported_architecture_raises_workflow_failed_error(self):
+        self.work.runtime = "python3.12"
+        self.work.architecture = "invalid_arch"
+        self.work.get_resolvers = Mock(return_value=[])
+        self.work.get_validators = Mock(return_value=[])
+        self.work.actions = [Mock()]
+
+        with self.assertRaises(WorkflowFailedError) as raised:
+            self.work.run()
+
+        self.assertEqual(
+            str(raised.exception),
+            "MyWorkflow:Validation - Architecture invalid_arch is not supported for runtime python3.12",
+        )
+
 
 class TestBaseWorkflow_repr(TestCase):
     class MyWorkflow(BaseWorkflow):

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -436,6 +436,19 @@ class TestBaseWorkflow_run(TestCase):
             "MyWorkflow:Validation - Architecture invalid_arch is not supported for runtime python3.12",
         )
 
+    def test_empty_binaries_can_skip_runtime_validation(self):
+        self.work.runtime = "unsupported"
+        self.work.get_resolvers = Mock(return_value=[])
+        self.work.get_validators = Mock(return_value=[])
+        self.work.get_runtime_validator = Mock(return_value=None)
+        action_mock = Mock()
+        self.work.actions = [action_mock]
+
+        self.work.run()
+
+        self.work.get_runtime_validator.assert_called_once_with()
+        action_mock.execute.assert_called_once_with()
+
 
 class TestBaseWorkflow_repr(TestCase):
     class MyWorkflow(BaseWorkflow):

--- a/tests/unit/workflows/nodejs_npm/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm/test_workflow.py
@@ -12,6 +12,7 @@ from aws_lambda_builders.actions import (
     MoveDependenciesAction,
 )
 from aws_lambda_builders.architecture import ARM64
+from aws_lambda_builders.exceptions import WorkflowFailedError
 from aws_lambda_builders.path_resolver import PathResolver
 from aws_lambda_builders.validator import RuntimeValidator
 from aws_lambda_builders.workflows.nodejs_npm.workflow import NodejsNpmWorkflow
@@ -238,6 +239,37 @@ class TestNodejsNpmWorkflow(TestCase):
         self.assertEqual(resolvers[0].binary, "npm")
         self.assertEqual(len(validators), 1)
         self.assertIsInstance(validators[0], RuntimeValidator)
+
+    def test_workflow_without_manifest_rejects_unsupported_runtime(self):
+        self.osutils.file_exists.return_value = False
+
+        workflow = NodejsNpmWorkflow(
+            "source", "artifacts", "scratch_dir", "source/manifest", runtime="nodejs1.x", osutils=self.osutils
+        )
+        with self.assertRaises(WorkflowFailedError) as raised:
+            workflow.run()
+
+        self.assertEqual(str(raised.exception), "NodejsNpmBuilder:Validation - Runtime nodejs1.x is not supported")
+
+    def test_workflow_without_manifest_rejects_unsupported_architecture(self):
+        self.osutils.file_exists.return_value = False
+
+        workflow = NodejsNpmWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "source/manifest",
+            runtime="nodejs20.x",
+            architecture="invalid_arch",
+            osutils=self.osutils,
+        )
+        with self.assertRaises(WorkflowFailedError) as raised:
+            workflow.run()
+
+        self.assertEqual(
+            str(raised.exception),
+            "NodejsNpmBuilder:Validation - Architecture invalid_arch is not supported for runtime nodejs20.x",
+        )
 
     def test_workflow_sets_up_npm_actions_without_combine_dependencies(self):
         self.osutils.file_exists.side_effect = [True, False, False]

--- a/tests/unit/workflows/nodejs_npm/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm/test_workflow.py
@@ -12,6 +12,8 @@ from aws_lambda_builders.actions import (
     MoveDependenciesAction,
 )
 from aws_lambda_builders.architecture import ARM64
+from aws_lambda_builders.path_resolver import PathResolver
+from aws_lambda_builders.validator import RuntimeValidator
 from aws_lambda_builders.workflows.nodejs_npm.workflow import NodejsNpmWorkflow
 from aws_lambda_builders.workflows.nodejs_npm.actions import (
     NodejsNpmPackAction,
@@ -205,6 +207,37 @@ class TestNodejsNpmWorkflow(TestCase):
         self.assertIsInstance(workflow.actions[2], CopySourceAction)
         self.assertIsInstance(workflow.actions[3], NodejsNpmrcCleanUpAction)
         self.assertIsInstance(workflow.actions[4], NodejsNpmLockFileCleanUpAction)
+
+    def test_workflow_without_manifest_skips_npm_resolution_and_validation(self):
+        self.osutils.file_exists.return_value = False
+
+        workflow = NodejsNpmWorkflow(
+            "source", "artifacts", "scratch_dir", "source/manifest", runtime="nodejs20.x", osutils=self.osutils
+        )
+
+        self.assertEqual(workflow.get_resolvers(), [])
+        self.assertEqual(workflow.get_validators(), [])
+
+    def test_workflow_with_manifest_retains_npm_resolution_and_validation(self):
+        self.osutils.file_exists.return_value = True
+
+        workflow = NodejsNpmWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "source/manifest",
+            runtime="nodejs20.x",
+            download_dependencies=False,
+            osutils=self.osutils,
+        )
+
+        resolvers = workflow.get_resolvers()
+        validators = workflow.get_validators()
+        self.assertEqual(len(resolvers), 1)
+        self.assertIsInstance(resolvers[0], PathResolver)
+        self.assertEqual(resolvers[0].binary, "npm")
+        self.assertEqual(len(validators), 1)
+        self.assertIsInstance(validators[0], RuntimeValidator)
 
     def test_workflow_sets_up_npm_actions_without_combine_dependencies(self):
         self.osutils.file_exists.side_effect = [True, False, False]

--- a/tests/unit/workflows/python_uv/test_workflow.py
+++ b/tests/unit/workflows/python_uv/test_workflow.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 from parameterized import parameterized_class
 
 from aws_lambda_builders.actions import CleanUpAction, CopyDependenciesAction, CopySourceAction
+from aws_lambda_builders.exceptions import WorkflowFailedError
 from aws_lambda_builders.workflows.python_uv.actions import PythonUvBuildAction
 from aws_lambda_builders.workflows.python_uv.utils import EXPERIMENTAL_FLAG_BUILD_PERFORMANCE, OSUtils
 from aws_lambda_builders.workflows.python_uv.workflow import PythonUvWorkflow
@@ -169,6 +170,34 @@ class TestPythonUvWorkflow(TestCase):
         validators = self.workflow.get_validators()
         # UV has built-in Python version handling, no external validators needed
         self.assertEqual(len(validators), 0)
+
+    def test_supported_runtime_runs_without_binary_resolution(self):
+        action_mock = Mock()
+        self.workflow.actions = [action_mock]
+
+        with patch("aws_lambda_builders.path_resolver.which", side_effect=AssertionError("binary resolution called")):
+            self.workflow.run()
+
+        action_mock.execute.assert_called_once_with()
+
+    def test_unsupported_runtime_is_rejected(self):
+        self.workflow.runtime = "python1.0"
+
+        with self.assertRaises(WorkflowFailedError) as raised:
+            self.workflow.run()
+
+        self.assertEqual(str(raised.exception), "PythonUvBuilder:Validation - Runtime python1.0 is not supported")
+
+    def test_unsupported_architecture_is_rejected(self):
+        self.workflow.architecture = "invalid_arch"
+
+        with self.assertRaises(WorkflowFailedError) as raised:
+            self.workflow.run()
+
+        self.assertEqual(
+            str(raised.exception),
+            "PythonUvBuilder:Validation - Architecture invalid_arch is not supported for runtime python3.9",
+        )
 
     @patch("aws_lambda_builders.workflows.python_uv.workflow.detect_uv_manifest")
     def test_workflow_auto_detects_manifest(self, mock_detect):

--- a/tests/unit/workflows/python_uv/test_workflow.py
+++ b/tests/unit/workflows/python_uv/test_workflow.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 from parameterized import parameterized_class
 
 from aws_lambda_builders.actions import CleanUpAction, CopyDependenciesAction, CopySourceAction
-from aws_lambda_builders.exceptions import WorkflowFailedError
 from aws_lambda_builders.workflows.python_uv.actions import PythonUvBuildAction
 from aws_lambda_builders.workflows.python_uv.utils import EXPERIMENTAL_FLAG_BUILD_PERFORMANCE, OSUtils
 from aws_lambda_builders.workflows.python_uv.workflow import PythonUvWorkflow
@@ -171,6 +170,9 @@ class TestPythonUvWorkflow(TestCase):
         # UV has built-in Python version handling, no external validators needed
         self.assertEqual(len(validators), 0)
 
+    def test_get_runtime_validator(self):
+        self.assertIsNone(self.workflow.get_runtime_validator())
+
     def test_supported_runtime_runs_without_binary_resolution(self):
         action_mock = Mock()
         self.workflow.actions = [action_mock]
@@ -180,24 +182,20 @@ class TestPythonUvWorkflow(TestCase):
 
         action_mock.execute.assert_called_once_with()
 
-    def test_unsupported_runtime_is_rejected(self):
-        self.workflow.runtime = "python1.0"
+    def test_runtime_validation_opt_out_preserves_previous_behavior(self):
+        for runtime, architecture in (("python1.0", "x86_64"), ("python3.9", "invalid_arch"), (None, "x86_64")):
+            with self.subTest(runtime=runtime, architecture=architecture):
+                action_mock = Mock()
+                self.workflow.runtime = runtime
+                self.workflow.architecture = architecture
+                self.workflow.actions = [action_mock]
 
-        with self.assertRaises(WorkflowFailedError) as raised:
-            self.workflow.run()
+                with patch(
+                    "aws_lambda_builders.path_resolver.which", side_effect=AssertionError("binary resolution called")
+                ):
+                    self.workflow.run()
 
-        self.assertEqual(str(raised.exception), "PythonUvBuilder:Validation - Runtime python1.0 is not supported")
-
-    def test_unsupported_architecture_is_rejected(self):
-        self.workflow.architecture = "invalid_arch"
-
-        with self.assertRaises(WorkflowFailedError) as raised:
-            self.workflow.run()
-
-        self.assertEqual(
-            str(raised.exception),
-            "PythonUvBuilder:Validation - Architecture invalid_arch is not supported for runtime python3.9",
-        )
+                action_mock.execute.assert_called_once_with()
 
     @patch("aws_lambda_builders.workflows.python_uv.workflow.detect_uv_manifest")
     def test_workflow_auto_detects_manifest(self, mock_detect):

--- a/tests/unit/workflows/ruby_bundler/test_workflow.py
+++ b/tests/unit/workflows/ruby_bundler/test_workflow.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from aws_lambda_builders.actions import CopySourceAction, CopyDependenciesAction, CleanUpAction
 from aws_lambda_builders.architecture import ARM64
+from aws_lambda_builders.exceptions import WorkflowFailedError
 from aws_lambda_builders.path_resolver import PathResolver
 from aws_lambda_builders.validator import RuntimeValidator
 from aws_lambda_builders.workflows.ruby_bundler.workflow import RubyBundlerWorkflow
@@ -76,6 +77,38 @@ class TestRubyBundlerWorkflow(TestCase):
         self.assertEqual(resolvers[0].binary, "ruby")
         self.assertEqual(len(validators), 1)
         self.assertIsInstance(validators[0], RuntimeValidator)
+
+    def test_workflow_without_download_dependencies_rejects_unsupported_runtime(self):
+        workflow = RubyBundlerWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "manifest",
+            runtime="ruby1.0",
+            download_dependencies=False,
+        )
+        with self.assertRaises(WorkflowFailedError) as raised:
+            workflow.run()
+
+        self.assertEqual(str(raised.exception), "RubyBundlerBuilder:Validation - Runtime ruby1.0 is not supported")
+
+    def test_workflow_without_download_dependencies_rejects_unsupported_architecture(self):
+        workflow = RubyBundlerWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "manifest",
+            runtime="ruby3.3",
+            architecture="invalid_arch",
+            download_dependencies=False,
+        )
+        with self.assertRaises(WorkflowFailedError) as raised:
+            workflow.run()
+
+        self.assertEqual(
+            str(raised.exception),
+            "RubyBundlerBuilder:Validation - Architecture invalid_arch is not supported for runtime ruby3.3",
+        )
 
     def test_must_validate_architecture(self):
         workflow = RubyBundlerWorkflow(

--- a/tests/unit/workflows/ruby_bundler/test_workflow.py
+++ b/tests/unit/workflows/ruby_bundler/test_workflow.py
@@ -2,6 +2,8 @@ from unittest import TestCase
 
 from aws_lambda_builders.actions import CopySourceAction, CopyDependenciesAction, CleanUpAction
 from aws_lambda_builders.architecture import ARM64
+from aws_lambda_builders.path_resolver import PathResolver
+from aws_lambda_builders.validator import RuntimeValidator
 from aws_lambda_builders.workflows.ruby_bundler.workflow import RubyBundlerWorkflow
 from aws_lambda_builders.workflows.ruby_bundler.actions import RubyBundlerInstallAction, RubyBundlerVendorAction
 
@@ -43,6 +45,37 @@ class TestRubyBundlerWorkflow(TestCase):
         self.assertEqual(len(workflow.actions), 1)
 
         self.assertIsInstance(workflow.actions[0], CopySourceAction)
+
+    def test_workflow_without_download_dependencies_skips_ruby_resolution_and_validation(self):
+        workflow = RubyBundlerWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "manifest",
+            runtime="ruby3.3",
+            download_dependencies=False,
+        )
+
+        self.assertEqual(workflow.get_resolvers(), [])
+        self.assertEqual(workflow.get_validators(), [])
+
+    def test_workflow_with_download_dependencies_retains_ruby_resolution_and_validation(self):
+        workflow = RubyBundlerWorkflow(
+            "source",
+            "artifacts",
+            "scratch_dir",
+            "manifest",
+            runtime="ruby3.3",
+            download_dependencies=True,
+        )
+
+        resolvers = workflow.get_resolvers()
+        validators = workflow.get_validators()
+        self.assertEqual(len(resolvers), 1)
+        self.assertIsInstance(resolvers[0], PathResolver)
+        self.assertEqual(resolvers[0].binary, "ruby")
+        self.assertEqual(len(validators), 1)
+        self.assertIsInstance(validators[0], RuntimeValidator)
 
     def test_must_validate_architecture(self):
         workflow = RubyBundlerWorkflow(


### PR DESCRIPTION
*Issue #, if available:*

#831

### Description of changes

Skip binary resolution and validation for copy-only workflows:
- Node.js when no `package.json` is present
- Ruby when `download_dependencies=False`

Existing behavior is preserved when the corresponding build tools are required. Added unit and integration coverage for both cases.

### Description of how you validated changes

- Full unit suite: 835 passed, 6 subtests passed
- Relevant integration tests: 9 passed
- Ruff, Black, and `git diff --check` passed

@reedham-aws (tagging you as requested would appreciate a look!)

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-lambda-builders/blob/develop/CONTRIBUTING.md#ai-usage)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.